### PR TITLE
Feat: handle login state using zustand and cookies

### DIFF
--- a/peer_web_frontend/.eslintrc.json
+++ b/peer_web_frontend/.eslintrc.json
@@ -29,6 +29,10 @@
     "react/function-component-definition": [
       "off"
     ],
-    "no-undef": "off"
+    "no-undef": "off",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error"
+    ]
   }
 }

--- a/peer_web_frontend/package-lock.json
+++ b/peer_web_frontend/package-lock.json
@@ -22,6 +22,7 @@
         "next": "13.4.19",
         "prettier": "^3.0.2",
         "react": "18.2.0",
+        "react-cookie": "^6.1.1",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.45.4",
         "swr": "^2.2.1",
@@ -929,6 +930,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.2.tgz",
+      "integrity": "sha512-DBpRoJGKJZn7RY92dPrgoMew8xCWc2P71beqsjyhEI/Ds9mOyVmBwtekyfhpwFIVt1WrxTonFifiOZ62V8CnNA=="
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
@@ -1597,6 +1612,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3817,6 +3840,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-6.1.1.tgz",
+      "integrity": "sha512-fuFRpf8LH6SfmVMowDUIRywJF5jAUDUWrm0EI5VdXfTl5bPcJ7B0zWbuYpT0Tvikx7Gs18MlvAT+P+744dUz2g==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -4414,6 +4450,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.1.1.tgz",
+      "integrity": "sha512-33S9x3CpdUnnjwTNs2Fgc41WGve2tdLtvaK2kPSbZRc5pGpz2vQFbRWMxlATsxNNe/Cy8SzmnmbuBM85jpZPtA==",
+      "dependencies": {
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0"
       }
     },
     "node_modules/uri-js": {

--- a/peer_web_frontend/package.json
+++ b/peer_web_frontend/package.json
@@ -24,6 +24,7 @@
     "next": "13.4.19",
     "prettier": "^3.0.2",
     "react": "18.2.0",
+    "react-cookie": "^6.1.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.4",
     "swr": "^2.2.1",

--- a/peer_web_frontend/src/app/login/page.tsx
+++ b/peer_web_frontend/src/app/login/page.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react'
 import { useForm, Controller, SubmitHandler } from 'react-hook-form'
 import axios from 'axios'
+import useAuthStore from '@/states/useAuthStore'
+import { useCookies } from 'react-cookie'
 
 interface ILoginFormInput {
   userEmail: string
@@ -14,6 +16,8 @@ const API_URL = 'https://localhost:8080'
 const Login = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
+  const { login } = useAuthStore()
+  const [, setCookie] = useCookies(['refreshToken'])
 
   const {
     handleSubmit,
@@ -31,7 +35,8 @@ const Login = () => {
       })
       .then((res) => {
         console.log(res)
-        // 로그인 상태 관리 로직
+        login(res.data.userId, res.data.accessToken)
+        setCookie('refreshToken', res.data.refreshToken, { path: '/' })
       })
       .catch((error) => {
         console.log(error.message)

--- a/peer_web_frontend/src/states/useAuthStore.tsx
+++ b/peer_web_frontend/src/states/useAuthStore.tsx
@@ -4,22 +4,41 @@ interface IAuthStore {
   isLogin: boolean
   userId: number | null
   accessToken: string | null
-  refreshToken: string | null
+  login: (userId: number, accessToken: string) => void
   logout: () => void
 }
 
-const useAuthStore = create<IAuthStore>((set) => ({
-  isLogin: false,
-  userId: null,
-  accessToken: null,
-  refreshToken: null,
-  logout: () =>
-    set(() => ({
-      isLogin: false,
-      userId: null,
-      accessToken: null,
-      refreshToken: null,
-    })),
-}))
+const useAuthStore = create<IAuthStore>((set) => {
+  const authDataJSON = localStorage.getItem('authData')
+  const authData = authDataJSON
+    ? JSON.parse(authDataJSON)
+    : { userId: null, accessToken: null }
+
+  return {
+    isLogin: !!authData.accessToken,
+    userId: authData.userId,
+    accessToken: authData.accessToken,
+    login: (userId, accessToken) => {
+      // save userId, accessToken to localStorage
+      const authDataToSave = { userId, accessToken }
+      localStorage.setItem('authData', JSON.stringify(authDataToSave))
+      // set state
+      set(() => ({
+        isLogin: true,
+        userId,
+        accessToken,
+      }))
+    },
+    logout: () => {
+      localStorage.removeItem('authData')
+      set(() => ({
+        isLogin: false,
+        userId: null,
+        accessToken: null,
+        refreshToken: null,
+      }))
+    },
+  }
+})
 
 export default useAuthStore


### PR DESCRIPTION
로그인 요청 후, 응답으로 받는 정보들을 처리하는 로직을 작성했습니다.
userId와 accessToken을 로컬스토리지에 저장하고 zustand를 이용해 전역 상태(useAuthStore.tsx)에 담아놓았습니다.
이 전역 상태 중 isLogin은 accessToken 값의 존재 유무로 판단합니다.
받아온 refreshToken은 useCookie를 사용해 쿠키에 저장합니다.