### PR TITLE
[C-MYPAGE-20,21,23] 링크 모듈 UI 변경

### DIFF
--- a/peer_web_frontend/src/app/profile/MyPage/page.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/page.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import ProfileCard from './panel/ProfileCard'
 import ProfileSection from './panel/ProfileSection'
 import { IUserProfile } from '@/types/IUserProfile'
+import ProfileLinksSection from './panel/ProfileLinksSection'
 
 // TODO 용훈님과 링크 관련 api 논의 필요 (link에 대한 이름도 받음)
 
@@ -11,14 +12,19 @@ const userInfo: IUserProfile = {
   profileImageUrl: 'https://picsum.photos/100',
   introduction: 'not a squad, salt',
   linkList: [
-    'https://profile.intra.42.fr/users/hyna',
-    'https://www.linkedin.com/in/%ED%98%84-%EB%82%98-98199227a/',
+    {
+      link: 'https://profile.intra.42.fr/users/hyna',
+      linkTitle: 'intra profile',
+    },
+    {
+      link: 'https://www.linkedin.com/in/%ED%98%84-%EB%82%98-98199227a/',
+      linkTitle: 'linkedIn',
+    },
   ],
   phone: '010-0707-2000',
   representAchievement: ['beginner'],
   achievements: ['beginner', 'too much talker', 'tester'],
   association: '42seoul',
-  userId: 'hyna',
   email: 'hyna@student.42seoul.kr',
 }
 
@@ -29,22 +35,23 @@ const MyProfile = () => {
   return (
     <div>
       <Typography>프로필</Typography>
-      {/* <Typography>소개</Typography>
-      <Typography>수정</Typography> */}
-      <ProfileSection title="소개">
+      <ProfileSection sectionTitle="introduction">
         {/* 프로필 이미지, 유저 이름, 소속(42?), 아이디, 이메일 표시 컴포넌트 */}
         <ProfileCard
           profileImageURL={userInfo.profileImageUrl}
           username={username}
           association={userInfo?.association}
-          userId={userInfo.userId}
           email={userInfo.email}
+          // introduction={userInfo.introduction}
         />
+        <div>biography</div>
       </ProfileSection>
-      <div>biography</div>
-      <div>achievements</div>
-      <div>skills</div>
-      <h3>링크</h3>
+      {/* profile home */}
+      <ProfileSection sectionTitle="achievements">achievements</ProfileSection>
+      <ProfileSection sectionTitle="skills">skills</ProfileSection>
+      <ProfileSection sectionTitle="links">
+        <ProfileLinksSection linkList={userInfo.linkList} />
+      </ProfileSection>
     </div>
   )
 }

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileCard.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileCard.tsx
@@ -7,7 +7,6 @@ interface IProfileCard {
   profileImageURL: string | null
   username: string
   association: string | null
-  userId: string
   email: string
 }
 
@@ -54,7 +53,6 @@ const ProfileCard = ({
   profileImageURL,
   username,
   association,
-  userId,
   email,
 }: IProfileCard) => {
   const [open, setOpen] = useState<boolean>(false)
@@ -91,10 +89,12 @@ const ProfileCard = ({
           }}
         >
           <Typography>{username}</Typography>
-          {association ? <p>{association}</p> : <p />}
-          <Typography>
-            {userId}({email})
-          </Typography>
+          {association ? (
+            <Typography>{association}</Typography>
+          ) : (
+            <Typography />
+          )}
+          <Typography>아이디({email})</Typography>
         </Stack>
       </Stack>
       <ProfileImageModal

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileLinksSection.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileLinksSection.tsx
@@ -1,12 +1,8 @@
 import { Box, Link, Typography } from '@mui/material'
 import React from 'react'
+import { IUserProfileLink } from '@/types/IUserProfile'
 
-interface IProfileLinksSectionProps {
-  link: string
-  linkTitle?: string
-}
-
-const ProfileLink = (props: IProfileLinksSectionProps) => {
+const ProfileLink = (props: IUserProfileLink) => {
   return (
     <>
       <Box
@@ -14,16 +10,20 @@ const ProfileLink = (props: IProfileLinksSectionProps) => {
         component="img"
         src={`https://www.google.com/s2/favicons?domain=${props.link}`}
       />
-      <Link href={props.link}>link</Link>
+      <Link href={props.link}>{props.linkTitle}</Link>
     </>
   )
 }
 
-const ProfileLinksSection = (props: Array<IProfileLinksSectionProps>) => {
+const ProfileLinksSection = ({
+  linkList,
+}: {
+  linkList: Array<IUserProfileLink>
+}) => {
   return (
     <div>
-      {props?.length ? (
-        props.map((item) => <ProfileLink key={item.link} {...item} />)
+      {linkList?.length ? (
+        linkList.map((item) => <ProfileLink key={item.link} {...item} />)
       ) : (
         <Typography>제공된 링크가 없습니다.</Typography>
       )}

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileSection.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileSection.tsx
@@ -2,23 +2,31 @@ import { Stack, Typography } from '@mui/material'
 import Link from 'next/link'
 import React from 'react'
 
+const sectionType = {
+  introduction: '소개',
+  achievements: '업적',
+  skills: '스킬',
+  links: '링크',
+}
+
 const ProfileSection = ({
-  title,
+  sectionTitle,
   children,
 }: {
-  title: string
+  sectionTitle: 'introduction' | 'achievements' | 'skills' | 'links'
   children: React.ReactNode
 }) => {
+  const sectionTypeMap = new Map(Object.entries(sectionType))
   return (
-    <div>
+    <section>
       <Stack direction="row" justifyContent="space-between">
-        <Typography>{title}</Typography>
+        <Typography>{sectionTypeMap.get(sectionTitle)}</Typography>
         <Link href={'profile/my-profile-setting'}>
           <Typography>수정</Typography>
         </Link>
       </Stack>
       {children}
-    </div>
+    </section>
   )
 }
 

--- a/peer_web_frontend/src/types/IUserProfile.ts
+++ b/peer_web_frontend/src/types/IUserProfile.ts
@@ -2,11 +2,15 @@ export interface IUserProfile {
   id: number
   profileImageUrl: string
   introduction: string
-  linkList: Array<string>
+  linkList: Array<IUserProfileLink>
   phone: string
   representAchievement: Array<string>
   achievements: Array<string>
   association: string | null
-  userId: string
   email: string
+}
+
+export interface IUserProfileLink {
+  link: string
+  linkTitle: string
 }


### PR DESCRIPTION
#### 구현사항
1. 링크에 대한 제목을 유저가 넣을 수 있도록 링크 리스트의 타입이 바뀌었습니다. 
2. ProfileSection이라는 컴포넌트로 프로필 페이지의 section을 구분해주었습니다.
3. profile page의 ui에 링크 모듈 컴포넌트를 추가하였습니다.

#### 추가 변경사항
1. ProfileSection에 sectionTitle을 넣도록 변경하였습니다. 그렇게 한 이유는 이후 편집으로 넘어갔을 때 라우팅 처리를 위해서 입니다.