### PR TITLE
[C-SIGN-03] 비밀번호 찾기 페이지 수정

### DIFF
--- a/peer_web_frontend/src/app/find-account/page.tsx
+++ b/peer_web_frontend/src/app/find-account/page.tsx
@@ -1,24 +1,13 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import SendEmailForm from './panel/SendEmailForm'
-import ChangePasswordForm from './panel/ChangePasswordForm'
+// import ChangePasswordForm from './panel/ChangePasswordForm'
 
 const FindAccount = () => {
-  const [passwordToken, setPasswordToken] = useState('')
-  const [passwordForm, setPasswordForm] = useState(false)
-
-  useEffect(() => {
-    if (passwordToken !== '') setPasswordForm(true)
-  }, [passwordToken])
-
   return (
     <>
-      {!passwordForm ? (
-        <SendEmailForm setPasswordToken={setPasswordToken} />
-      ) : (
-        <ChangePasswordForm token={passwordToken} />
-      )}
+      <SendEmailForm />
     </>
   )
 }

--- a/peer_web_frontend/src/app/find-account/panel/SendCodeForm.tsx
+++ b/peer_web_frontend/src/app/find-account/panel/SendCodeForm.tsx
@@ -1,38 +1,53 @@
 'use client'
 
 import { TextField, Typography, Button, InputLabel } from '@mui/material'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import axios from 'axios'
+import { useRouter } from 'next/navigation'
 
-const SendCodeForm = ({
-  email,
-  setPasswordToken,
-}: {
-  email: string
-  setPasswordToken: (newValue: string) => void
-}) => {
+const SendCodeForm = ({ email }: { email: string }) => {
   const [code, setCode] = useState('')
   const [isAuthing, setIsAuthing] = useState(false)
+  const [timer, setTimer] = useState(5 * 60)
+  const router = useRouter()
+
+  useEffect(() => {
+    const countdown = setInterval(() => {
+      setTimer((prevTimer) => prevTimer - 1)
+    }, 1000)
+
+    return () => {
+      clearInterval(countdown)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (timer === 0) {
+      alert('인증 코드가 만료되었습니다.')
+      location.reload() // 페이지 새로고침
+    }
+  }, [timer])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsAuthing(true)
-    const jsonData = JSON.stringify({ email, code })
-    console.log(jsonData)
+    const codeData = JSON.stringify({ email, code })
+    console.log(codeData)
 
     try {
       // 테스트용 post요청 코드
-      const res = await axios.post(`http://localhost:5000/password_change`, {
-        jsonData,
+      const res = await axios.post(`https://localhost:8080/password_change`, {
+        codeData,
       })
       console.log(res)
-      // 임의
-      setPasswordToken(res.data.token)
+      // 추후 모달로 변경
+      alert(
+        '메일로 임시 비밀번호가 전송되었습니다. 로그인 페이지로 이동합니다.',
+      )
+      router.push('/login')
     } catch (error) {
       console.log(error)
-      // 테스트용 임시 코드 (추후삭제)
-      console.log('setToken!')
-      setPasswordToken('1234')
+      alert('인증 코드가 일치하지 않습니다.')
     }
     setIsAuthing(false)
   }
@@ -41,6 +56,11 @@ const SendCodeForm = ({
     <form onSubmit={handleSubmit}>
       <InputLabel htmlFor="auth-code">인증코드</InputLabel>
       <Typography>이메일로 전송된 인증코드를 입력해주세요.</Typography>
+      {timer > 0 && (
+        <Typography>{`남은 시간: ${Math.floor(timer / 60)}분 ${
+          timer % 60
+        }초`}</Typography>
+      )}
       <TextField
         type="text"
         name="auth-code"

--- a/peer_web_frontend/src/app/find-account/panel/SendEmailForm.tsx
+++ b/peer_web_frontend/src/app/find-account/panel/SendEmailForm.tsx
@@ -5,11 +5,7 @@ import SendCodeForm from './SendCodeForm'
 import axios from 'axios'
 import { InputLabel, TextField, Typography, Button } from '@mui/material'
 
-const SendEmailForm = ({
-  setPasswordToken,
-}: {
-  setPasswordToken: (newValue: string) => void
-}) => {
+const SendEmailForm = () => {
   const [email, setEmail] = useState('')
   const [isEmailSuccessful, setIsEmailSuccessful] = useState(false)
   const {
@@ -24,7 +20,7 @@ const SendEmailForm = ({
     try {
       console.log('isSubmitting:', isSubmitting)
       // 테스트용 post요청 코드
-      const res = await axios.post(`http://localhost:5000/find`, {
+      const res = await axios.post(`http://localhost:8080/find`, {
         data,
       })
       console.log(res)
@@ -77,9 +73,7 @@ const SendEmailForm = ({
           </Button>
         )}
       </form>
-      {isEmailSuccessful && (
-        <SendCodeForm email={email} setPasswordToken={setPasswordToken} />
-      )}
+      {isEmailSuccessful && <SendCodeForm email={email} />}
     </div>
   )
 }


### PR DESCRIPTION
비밀번호 찾기 과정이 임시비밀번호 발급으로 바뀜에 따라 코드 인증 후 로그인 페이지로 이동하는 로직으로 다시 작성했습니다.
추가로 인증코드 메일을 전송하면 유효시간(5분)을 설정해 사용자에게 타이머가 보여지고, 유효시간이 지나면 페이지를 새로고침하도록 했습니다.