### PR TITLE
[C-MYPAGE] 소개 파트 수정 모달 추가 구현

### DIFF
--- a/peer_web_frontend/src/app/profile/MyPage/page.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/page.tsx
@@ -5,7 +5,7 @@ import ProfileCard from './panel/ProfileCard'
 import ProfileSection from './panel/ProfileSection'
 import { IUserProfile } from '@/types/IUserProfile'
 import ProfileLinksSection from './panel/ProfileLinksSection'
-import ModalContainer from '@/components/ModalContainer'
+import CuModal from '@/components/CuModal'
 import ProfileBioEditor from './panel/ProfileBioEditor'
 import ProfileLinkEditor from './panel/ProfileLinkEditor'
 
@@ -111,11 +111,11 @@ const MyProfile = () => {
       {/* </Grid> */}
 
       {/* modals */}
-      <ModalContainer
+      <CuModal
         open={modalOpen.introduction}
         handleClose={() => setModalType('')}
-        title="프로필 소개 섹션 수정 모달"
-        description="닉네임, 자기 소개 수정 폼"
+        ariaTitle="프로필 소개 섹션 수정 모달"
+        ariaDescription="닉네임, 자기 소개 수정 폼"
       >
         <ProfileBioEditor
           data={{
@@ -127,18 +127,18 @@ const MyProfile = () => {
           }}
           closeModal={() => setModalType('')}
         />
-      </ModalContainer>
-      <ModalContainer
+      </CuModal>
+      <CuModal
         open={modalOpen.links}
         handleClose={() => setModalType('')}
-        title="프로필 링크 섹션 수정 모달"
-        description="링크 수정 폼"
+        ariaTitle="프로필 링크 섹션 수정 모달"
+        ariaDescription="링크 수정 폼"
       >
         <ProfileLinkEditor
           links={userInfo.linkList}
           closeModal={() => setModalType('')}
         />
-      </ModalContainer>
+      </CuModal>
     </Box>
   )
 }

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileBioEditor.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileBioEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React from 'react'
 import SettingContainer from './SettingContainer'
-import { Avatar, Box, Grid, Typography } from '@mui/material'
+import { Avatar, Grid, Typography } from '@mui/material'
 import { IProfileCard } from '@/types/IUserProfile'
 import { useForm, Controller } from 'react-hook-form'
 import CuTextField from '@/components/CuTextField'
@@ -65,16 +65,16 @@ const ProfileBioEditor = ({
             <Grid item xs={9}>
               <Controller
                 render={({ field }) => (
-                  <Box>
-                    <CuTextField
-                      id="nickname"
-                      variant="outlined"
-                      field={{ ...field }}
-                      fullWidth={true}
-                      error={errors.nickname ? true : false}
-                      autoComplete="off"
-                    />
-                  </Box>
+                  <CuTextField
+                    id="nickname"
+                    variant="outlined"
+                    field={{ ...field }}
+                    fullWidth={true}
+                    error={errors.nickname ? true : false}
+                    autoComplete="off"
+                    placeholder="닉네임은 비워둘 수 없습니다."
+                    inputProps={{ maxLength: 7 }}
+                  />
                 )}
                 name="nickname"
                 control={control}
@@ -113,6 +113,7 @@ const ProfileBioEditor = ({
                     field={field}
                     autoComplete="off"
                     fullWidth
+                    inputProps={{ maxLength: 150 }}
                   />
                 )}
                 name="introduction"

--- a/peer_web_frontend/src/components/CuTextField.tsx
+++ b/peer_web_frontend/src/components/CuTextField.tsx
@@ -12,6 +12,8 @@ const CuTextField = ({
   autoComplete,
   fullWidth,
   error,
+  placeholder,
+  inputProps,
 }: {
   id?: string
   field?: any
@@ -21,6 +23,8 @@ const CuTextField = ({
   autoComplete?: string
   fullWidth?: boolean
   error?: boolean
+  placeholder?: string
+  inputProps?: any
 }) => {
   return (
     <TextField
@@ -32,6 +36,8 @@ const CuTextField = ({
       error={error}
       sx={style}
       autoComplete={autoComplete}
+      placeholder={placeholder}
+      inputProps={inputProps}
     />
   )
 }


### PR DESCRIPTION
### 구현 사항
1. 닉네임이 빈칸일 경우 띄워주는 placeholder를 추가하였습니다.
2. 닉네임 인풋박스와 자기소개 인풋 박스에 쓸 수 있는 최대 글자 수를 제한하였습니다.
![C-MYPAGE 소개 수정 모달 에러 핸들링](https://github.com/peer-42seoul/Peer-Frontend/assets/91731260/75760ee9-5965-4c14-b93c-63d4d9745197)

### 수정 사항
- CuTextField
    1. placeholder가 추가되었습니다. 
        - 필수 작성란일 경우 해당사항을 알려주기 위함입니다.
    2. inputProps가 추가되었습니다.
        - pattern이나 maxLength등등을 넣기 위함입니다.
