### PR TITLE
[PUBLIC & C-MYPAGE] pc뷰 서브 네비게이션 바 및 모바일 pc 구분 위한 theme설정

### DIFF
--- a/peer_web_frontend/src/app/layout.tsx
+++ b/peer_web_frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import '../../styles/reset.css'
 import NavBar from './panel/NavBar'
 import Header from './panel/Header'
 import { Box, Stack } from '@mui/material'
+import MuiThemeProvider from '@/app/panel/MuiThemeProvider'
 
 export const metadata: Metadata = {
   title: 'peer',
@@ -19,16 +20,18 @@ export default function RootLayout({
     <html lang="ko">
       <head />
       <body>
-        <div className="layout">
-          <NavBar />
-          <Stack flex={1}>
-            <Box>
-              <Header />
-            </Box>
-            {/* 헤더 고정 시 여기에 margin-top: 추가 */}
-            <Box sx={{ marginBottom: '100px' }}>{children}</Box>
-          </Stack>
-        </div>
+        <MuiThemeProvider>
+          <div className="layout">
+            <NavBar />
+            <Stack flex={1}>
+              <Box>
+                <Header />
+              </Box>
+              {/* 헤더 고정 시 여기에 margin-top: 추가 */}
+              <Box sx={{ marginBottom: '100px' }}>{children}</Box>
+            </Stack>
+          </div>
+        </MuiThemeProvider>
         <div id="modal-root"></div>
       </body>
     </html>

--- a/peer_web_frontend/src/app/panel/MuiThemeProvider.tsx
+++ b/peer_web_frontend/src/app/panel/MuiThemeProvider.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { ThemeProvider, createTheme } from '@mui/material'
+
+export const theme = createTheme({
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 480, // mobile과 pc를 구분하기 위해 테마 설정을 하였습니다.
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
+})
+
+const MuiThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>
+}
+
+export default MuiThemeProvider

--- a/peer_web_frontend/src/app/profile/MyPage/layout.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/layout.tsx
@@ -1,0 +1,20 @@
+import { Box, Grid } from '@mui/material'
+import React from 'react'
+import SubNavBar from './panel/SubNavBar'
+
+const Layout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Box>
+      <Grid container>
+        <Grid item sm={3}>
+          <SubNavBar />
+        </Grid>
+        <Grid item xs={12} sm={9}>
+          {children}
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+export default Layout

--- a/peer_web_frontend/src/app/profile/MyPage/page.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/page.tsx
@@ -5,7 +5,7 @@ import ProfileCard from './panel/ProfileCard'
 import ProfileSection from './panel/ProfileSection'
 import { IUserProfile } from '@/types/IUserProfile'
 import ProfileLinksSection from './panel/ProfileLinksSection'
-import ModalContainer from '@/components/ModalContainer'
+import CuModal from '@/components/CuModal'
 import ProfileBioEditor from './panel/ProfileBioEditor'
 import ProfileLinkEditor from './panel/ProfileLinkEditor'
 
@@ -111,7 +111,7 @@ const MyProfile = () => {
       {/* </Grid> */}
 
       {/* modals */}
-      <ModalContainer
+      <CuModal
         open={modalOpen.introduction}
         handleClose={() => setModalType('')}
         title="프로필 소개 섹션 수정 모달"
@@ -127,8 +127,8 @@ const MyProfile = () => {
           }}
           closeModal={() => setModalType('')}
         />
-      </ModalContainer>
-      <ModalContainer
+      </CuModal>
+      <CuModal
         open={modalOpen.links}
         handleClose={() => setModalType('')}
         title="프로필 링크 섹션 수정 모달"
@@ -138,7 +138,7 @@ const MyProfile = () => {
           links={userInfo.linkList}
           closeModal={() => setModalType('')}
         />
-      </ModalContainer>
+      </CuModal>
     </Box>
   )
 }

--- a/peer_web_frontend/src/app/profile/MyPage/panel/SubNavBar.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/SubNavBar.tsx
@@ -1,0 +1,61 @@
+'use client'
+import useMedia from '@/hook/useMedia'
+import { Tab, Tabs } from '@mui/material'
+import { useRouter } from 'next/navigation'
+import React, { useState } from 'react'
+
+const SubNavBar = () => {
+  const router = useRouter()
+  const [value, setValue] = useState(0)
+  const { isPc } = useMedia()
+
+  if (!isPc) {
+    console.log(isPc)
+    return <div></div>
+  }
+
+  return (
+    <div>
+      <Tabs
+        orientation="vertical"
+        value={value}
+        onChange={(event, newValue) => setValue(newValue)}
+        sx={{ borderRight: 1, borderColor: 'divider' }}
+        variant="fullWidth"
+      >
+        <Tab
+          label="프로필"
+          onClick={() => {
+            router.push('/profile/MyPage')
+          }}
+        />
+        <Tab
+          label="관심리스트"
+          onClick={() => {
+            router.push('/')
+          }}
+        />
+        <Tab
+          label="쪽지"
+          onClick={() => {
+            router.push('/')
+          }}
+        />
+        <Tab
+          label="개인정보"
+          onClick={() => {
+            router.push('/')
+          }}
+        />
+        <Tab
+          label="홈페이지 설정"
+          onClick={() => {
+            router.push('/')
+          }}
+        />
+      </Tabs>
+    </div>
+  )
+}
+
+export default SubNavBar


### PR DESCRIPTION
### 구현사항

1. 마이페이지 pc뷰의 서브 네비게이션 바를 추가하였습니다.
![C-MYPAGE 서브네비게이션바PC](https://github.com/peer-42seoul/Peer-Frontend/assets/91731260/d5a1f9a5-bd1c-4e75-8923-d036ce83ed55)
2. sm prop이 480 이상일 때 작동하도록 테마를 커스터마이징 해주었습니다.
