### PR TITLE
[PUBLIC & C-MYPAGE] 공통 토스트 컴포넌트 useToast 구현 및 링크 수정 에러 헨들링

### DIFF
--- a/peer_web_frontend/src/app/profile/MyPage/page.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/page.tsx
@@ -8,6 +8,7 @@ import ProfileLinksSection from './panel/ProfileLinksSection'
 import CuModal from '@/components/CuModal'
 import ProfileBioEditor from './panel/ProfileBioEditor'
 import ProfileLinkEditor from './panel/ProfileLinkEditor'
+import useToast from '@/hook/useToast'
 
 const userInfo: IUserProfile = {
   id: 1,
@@ -17,12 +18,12 @@ const userInfo: IUserProfile = {
   linkList: [
     {
       id: 1,
-      link: 'https://profile.intra.42.fr/users/hyna',
+      linkUrl: 'https://profile.intra.42.fr/users/hyna',
       linkName: 'intra profile',
     },
     {
       id: 2,
-      link: 'https://www.linkedin.com/in/%ED%98%84-%EB%82%98-98199227a/',
+      linkUrl: 'https://www.linkedin.com/in/%ED%98%84-%EB%82%98-98199227a/',
       linkName: 'linkedIn',
     },
   ],
@@ -50,6 +51,7 @@ const MyProfile = () => {
     skills: false,
     links: false,
   })
+  const [toastMessage, setToastMessage] = useState<string>('')
 
   useEffect(() => {
     const newModalOpen: IModals = {
@@ -73,6 +75,8 @@ const MyProfile = () => {
 
     setModalOpen(newModalOpen)
   }, [modalType])
+
+  const { CuToast, isOpen, openToast, closeToast } = useToast()
 
   return (
     <Box>
@@ -137,8 +141,13 @@ const MyProfile = () => {
         <ProfileLinkEditor
           links={userInfo.linkList}
           closeModal={() => setModalType('')}
+          setToastMessage={setToastMessage}
+          setToastOpen={openToast}
         />
       </CuModal>
+      <CuToast open={isOpen} onClose={closeToast} severity="error">
+        <Typography>{toastMessage}</Typography>
+      </CuToast>
     </Box>
   )
 }

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileBioEditor.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileBioEditor.tsx
@@ -28,12 +28,14 @@ const ProfileBioEditor = ({
     handleSubmit,
     control,
     formState: { errors },
+    getValues,
   } = useForm<IFormInput>({
     defaultValues: defaultValues,
     mode: 'onChange',
   })
 
   const onSubmit = (data: IFormInput) => {
+    console.log(getValues('introduction'))
     console.log('on positive click', data)
   }
 
@@ -68,7 +70,7 @@ const ProfileBioEditor = ({
                   <CuTextField
                     id="nickname"
                     variant="outlined"
-                    field={{ ...field }}
+                    field={field}
                     fullWidth={true}
                     error={errors.nickname ? true : false}
                     autoComplete="off"

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileLinkEditor.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileLinkEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import SettingContainer from './SettingContainer'
 import { IUserProfileLink } from '@/types/IUserProfile'
-import { Box, Grid, Typography } from '@mui/material'
+import { Box, Grid } from '@mui/material'
 import { Controller, useForm } from 'react-hook-form'
 import CuTextField from '@/components/CuTextField'
 import CuTextFieldLabel from '@/components/CuTextFieldLabel'
@@ -28,13 +28,22 @@ const ProfileLinkEditor = ({
       linkName: '',
       link: '',
     })
-  console.log(defaultValues)
-  const onSubmit = (data: Array<IUserProfileLink>) =>
+
+  const onSubmit = (data: Array<IUserProfileLink>) => {
+    data.map((link) => {
+      if (link.link && !link.linkName) {
+        return
+      } else if (link.linkName && !link.link) {
+        return
+      }
+    })
     console.log('on positive click', data)
+  }
 
   const {
     handleSubmit,
     getFieldState,
+    // getValues,
     control,
     formState: { errors },
   } = useForm<Array<IUserProfileLink>>({
@@ -64,6 +73,7 @@ const ProfileLinkEditor = ({
                         field={{ ...field, fullWidth: true }}
                         autoComplete="off"
                         error={errors[i]?.linkName ? true : false}
+                        fullWidth
                       />
                     )}
                     name={`${i}.linkName`}
@@ -88,9 +98,9 @@ const ProfileLinkEditor = ({
                               field={{ ...field, fullWidth: true }}
                               autoComplete="off"
                               error={errors[i]?.link ? true : false}
+                              fullWidth
                             />
                           </Box>
-                          {errors[i]?.link && <Typography>test</Typography>}
                         </Box>
                       )}
                       rules={{

--- a/peer_web_frontend/src/app/profile/MyPage/panel/ProfileLinkEditor.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/ProfileLinkEditor.tsx
@@ -10,14 +10,18 @@ import CuTextFieldLabel from '@/components/CuTextFieldLabel'
 const ProfileLinkEditor = ({
   closeModal,
   links,
+  setToastMessage,
+  setToastOpen,
 }: {
   closeModal: () => void
   links: Array<IUserProfileLink>
+  setToastMessage: (message: string) => void
+  setToastOpen: (open: boolean) => void
 }) => {
   const defaultValues: Array<IUserProfileLink> = links.map((link) => ({
     id: link.id,
     linkName: link.linkName,
-    link: link.link,
+    linkUrl: link.linkUrl,
   }))
 
   const emptyLinksLength: number = 3 - links.length
@@ -26,23 +30,30 @@ const ProfileLinkEditor = ({
     defaultValues.push({
       id: links.length + i + 1,
       linkName: '',
-      link: '',
+      linkUrl: '',
     })
 
   const onSubmit = (data: Array<IUserProfileLink>) => {
-    data.map((link) => {
-      if (link.link && !link.linkName) {
+    for (let i = 0; i < 3; i++) {
+      if (data[i].linkUrl && !data[i].linkName) {
+        setToastMessage(`${i + 1}번째 링크의 제목이 없습니다. 확인해주세요!`)
+        setToastOpen(true)
         return
-      } else if (link.linkName && !link.link) {
+      } else if (data[i].linkName && !data[i].linkUrl) {
+        setToastMessage(
+          `${data[i].linkName}의 링크 주소가 없습니다. 확인해주세요!`,
+        )
+        setToastOpen(true)
         return
       }
-    })
+    }
+
     console.log('on positive click', data)
   }
 
   const {
     handleSubmit,
-    getFieldState,
+    // getFieldState,
     // getValues,
     control,
     formState: { errors },
@@ -50,73 +61,70 @@ const ProfileLinkEditor = ({
     defaultValues: { ...defaultValues },
     mode: 'onChange',
   })
-  // const fieldState = getFieldState('firstName')
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <SettingContainer onNegativeClick={closeModal} settingTitle="links">
-        <Grid container rowSpacing={2}>
-          {defaultValues.map((link, i) => {
-            return (
-              <Grid item container xs={12} key={link.id} rowSpacing={1}>
-                <Grid item xs={3}>
-                  <CuTextFieldLabel htmlFor={`${i}.linkName`}>
-                    제목
-                  </CuTextFieldLabel>
-                </Grid>
-                <Grid item xs={9}>
-                  <Controller
-                    render={({ field }) => (
-                      <CuTextField
-                        variant="outlined"
-                        id={`${i}.linkName`}
-                        field={{ ...field, fullWidth: true }}
-                        autoComplete="off"
-                        error={errors[i]?.linkName ? true : false}
-                        fullWidth
-                      />
-                    )}
-                    name={`${i}.linkName`}
-                    control={control}
-                    rules={{ required: getFieldState(`${i}.link`).isDirty }}
-                  />
-                </Grid>
-                <Grid item container xs={12}>
+    <Box>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <SettingContainer onNegativeClick={closeModal} settingTitle="links">
+          <Grid container rowSpacing={2}>
+            {defaultValues.map((link, i) => {
+              return (
+                <Grid item container xs={12} key={link.id} rowSpacing={1}>
                   <Grid item xs={3}>
-                    <CuTextFieldLabel htmlFor={`${i}.link`}>
-                      링크
+                    <CuTextFieldLabel htmlFor={`${i}.linkName`}>
+                      제목
                     </CuTextFieldLabel>
                   </Grid>
                   <Grid item xs={9}>
                     <Controller
                       render={({ field }) => (
-                        <Box>
-                          <Box>
-                            <CuTextField
-                              variant="outlined"
-                              id={`${i}.link`}
-                              field={{ ...field, fullWidth: true }}
-                              autoComplete="off"
-                              error={errors[i]?.link ? true : false}
-                              fullWidth
-                            />
-                          </Box>
-                        </Box>
+                        <CuTextField
+                          variant="outlined"
+                          id={`${i}.linkName`}
+                          field={{ ...field, fullWidth: true }}
+                          autoComplete="off"
+                          error={errors[i]?.linkName ? true : false}
+                          fullWidth
+                        />
                       )}
-                      rules={{
-                        required: getFieldState(`${i}.linkName`).isDirty,
-                      }}
-                      name={`${i}.link`}
+                      name={`${i}.linkName`}
                       control={control}
                     />
                   </Grid>
+                  <Grid item container xs={12}>
+                    <Grid item xs={3}>
+                      <CuTextFieldLabel htmlFor={`${i}.linkUrl`}>
+                        링크
+                      </CuTextFieldLabel>
+                    </Grid>
+                    <Grid item xs={9}>
+                      <Controller
+                        render={({ field }) => (
+                          <Box>
+                            <Box>
+                              <CuTextField
+                                variant="outlined"
+                                id={`${i}.linkUrl`}
+                                field={{ ...field, fullWidth: true }}
+                                autoComplete="off"
+                                error={errors[i]?.linkUrl ? true : false}
+                                fullWidth
+                              />
+                            </Box>
+                          </Box>
+                        )}
+                        name={`${i}.linkUrl`}
+                        control={control}
+                      />
+                    </Grid>
+                  </Grid>
                 </Grid>
-              </Grid>
-            )
-          })}
-        </Grid>
-      </SettingContainer>
-    </form>
+              )
+            })}
+          </Grid>
+        </SettingContainer>
+      </form>
+    </Box>
   )
 }
 

--- a/peer_web_frontend/src/app/profile/MyPage/panel/SettingContainer.tsx
+++ b/peer_web_frontend/src/app/profile/MyPage/panel/SettingContainer.tsx
@@ -15,12 +15,12 @@ const SettingContainer = ({
   settingTitle,
   onNegativeClick,
   children,
-  onPositiveClick,
-}: {
+} // onPositiveClick,
+: {
   settingTitle: string
   onNegativeClick: (object: any) => void
   children: React.ReactNode
-  onPositiveClick?: (object: any) => void
+  // onPositiveClick?: (object: any) => void
 }) => {
   return (
     <div>
@@ -29,15 +29,15 @@ const SettingContainer = ({
       <Button variant="contained" onClick={onNegativeClick}>
         취소
       </Button>
-      {onPositiveClick ? (
+      {/* {onPositiveClick ? (
         <Button variant="contained" onClick={onPositiveClick}>
           완료
         </Button>
-      ) : (
-        <Button variant="contained" type="submit">
-          완료
-        </Button>
-      )}
+      ) : ( */}
+      <Button variant="contained" type="submit">
+        완료
+      </Button>
+      {/* )} */}
     </div>
   )
 }

--- a/peer_web_frontend/src/components/CuToast.tsx
+++ b/peer_web_frontend/src/components/CuToast.tsx
@@ -1,0 +1,46 @@
+import MuiAlert, { AlertColor, AlertProps } from '@mui/material/Alert'
+import { Snackbar, SxProps } from '@mui/material'
+import React from 'react'
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  function Alert(props, ref) {
+    return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
+  },
+)
+
+const CuToast = ({
+  open,
+  autoHideDuration,
+  onClose,
+  severity,
+  sx,
+  children,
+}: {
+  open: boolean
+  autoHideDuration?: number
+  onClose: (
+    event?: React.SyntheticEvent | Event,
+    reason?: string,
+  ) => void | undefined
+  severity?: AlertColor | undefined
+  sx?: SxProps
+  children: React.ReactNode
+}) => {
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={autoHideDuration ? autoHideDuration : 6000}
+      onClose={onClose}
+    >
+      <Alert
+        onClose={onClose}
+        severity={severity}
+        sx={sx ? sx : { width: '100%' }}
+      >
+        {children}
+      </Alert>
+    </Snackbar>
+  )
+}
+
+export default CuToast

--- a/peer_web_frontend/src/hook/useToast.tsx
+++ b/peer_web_frontend/src/hook/useToast.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import CuToast from '@/components/CuToast'
+
+const useToast = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const openToast = () => setIsOpen(true)
+  const closeToast = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string,
+  ) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    setIsOpen(false)
+  }
+
+  return { CuToast, isOpen, openToast, closeToast }
+}
+
+export default useToast

--- a/peer_web_frontend/src/types/IUserProfile.ts
+++ b/peer_web_frontend/src/types/IUserProfile.ts
@@ -12,7 +12,7 @@ export interface IUserProfile {
 
 export interface IUserProfileLink {
   id: number
-  link: string
+  linkUrl: string
   linkName: string
 }
 


### PR DESCRIPTION
### 구현 사항

#### `CuToast`

1. 공통 toast 컴포넌트를 구현하였습니다.
2. mui의 예시코드를 활용하였으며, severity를 'error'로 사용하면 뜨는 ui는 다음과 같습니다.

<img width="449" alt="스크린샷 2023-10-06 오후 5 28 45" src="https://github.com/peer-42seoul/Peer-Frontend/assets/91731260/0304dfc5-57ad-4090-b8ca-16754221b864">

#### `useToast`
1. mui의 예시코드를 활용하였습니다.
2. isOpen, openToast, closeToast, CuToast를 리턴합니다.

#### 링크 수정 에러 핸들링

1. form submit시 문제가 있을 경우 toast를 띄우도록 처리했습니다.


