### PR TITLE
[D-TP-21~30, 39, 41] 팀 페이지 - 메인 페이지 추가

### DIFF
--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -1,16 +1,23 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { Typography, Stack, Box } from '@mui/material'
-import TeamInfoContainer from './panel/TeamInfoContainer'
 import CuButton from '@/components/CuButton'
+import TeamInfoContainer from './panel/TeamInfoContainer'
 
 const TeamsPage = ({ params }: { params: { id: string } }) => {
+  const router = useRouter()
   const { id } = params
 
   return (
     <Stack spacing={2}>
       {/* 팀 리스트로 가는 기능 추가하기 */}
-      <Typography sx={{ color: '#9B9B9B' }}>팀리스트로 돌아가기</Typography>
+      <Typography
+        onClick={() => router.push('/team-list')}
+        sx={{ color: '#9B9B9B', cursor: 'pointer' }}
+      >
+        팀리스트로 돌아가기
+      </Typography>
       <TeamInfoContainer id={Number(id)} />
       {/* 임시 컴포넌트 */}
       <Box

--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Typography } from '@mui/material'
 import TeamInfoContainer from './panel/TeamInfoContainer'
 
 const TeamsPage = ({ params }: { params: { id: string } }) => {
@@ -7,8 +8,8 @@ const TeamsPage = ({ params }: { params: { id: string } }) => {
 
   return (
     <>
-      {/* <Typography>팀 페이지</Typography> */}
-      {/* <Typography>{id}</Typography> */}
+      {/* 뒤로가기 기능 추가하기 */}
+      <Typography>팀리스트로 돌아가기</Typography>
       <TeamInfoContainer id={Number(id)} />
     </>
   )

--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Typography, Stack } from '@mui/material'
+import { Typography, Stack, Box } from '@mui/material'
 import TeamInfoContainer from './panel/TeamInfoContainer'
+import CuButton from '@/components/CuButton'
 
 const TeamsPage = ({ params }: { params: { id: string } }) => {
   const { id } = params
@@ -11,6 +12,14 @@ const TeamsPage = ({ params }: { params: { id: string } }) => {
       {/* 팀 리스트로 가는 기능 추가하기 */}
       <Typography sx={{ color: '#9B9B9B' }}>팀리스트로 돌아가기</Typography>
       <TeamInfoContainer id={Number(id)} />
+      <Box>Drag And Drop</Box>
+      <CuButton
+        message={'팀페이지 수정'}
+        action={() => {}}
+        variant={'contained'}
+        fullWidth={false}
+        disabled
+      />
     </Stack>
   )
 }

--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -11,7 +11,6 @@ const TeamsPage = ({ params }: { params: { id: string } }) => {
 
   return (
     <Stack spacing={2}>
-      {/* 팀 리스트로 가는 기능 추가하기 */}
       <Typography
         onClick={() => router.push('/team-list')}
         sx={{ color: '#9B9B9B', cursor: 'pointer' }}

--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -8,11 +8,21 @@ const TeamsPage = ({ params }: { params: { id: string } }) => {
   const { id } = params
 
   return (
-    <Stack>
+    <Stack spacing={2}>
       {/* 팀 리스트로 가는 기능 추가하기 */}
       <Typography sx={{ color: '#9B9B9B' }}>팀리스트로 돌아가기</Typography>
       <TeamInfoContainer id={Number(id)} />
-      <Box>Drag And Drop</Box>
+      {/* 임시 컴포넌트 */}
+      <Box
+        sx={{
+          width: 600,
+          height: 300,
+          border: 1.55,
+          padding: 2,
+        }}
+      >
+        Drag And Drop
+      </Box>
       <CuButton
         message={'팀페이지 수정'}
         action={() => {}}

--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import { Typography } from '@mui/material'
+import TeamInfoContainer from './panel/TeamInfoContainer'
 
 const TeamsPage = ({ params }: { params: { id: string } }) => {
   const { id } = params
 
   return (
     <>
-      <Typography>팀 페이지</Typography>
-      <Typography>{id}</Typography>
+      {/* <Typography>팀 페이지</Typography> */}
+      {/* <Typography>{id}</Typography> */}
+      <TeamInfoContainer id={Number(id)} />
     </>
   )
 }

--- a/src/app/teams/@main/[id]/page.tsx
+++ b/src/app/teams/@main/[id]/page.tsx
@@ -1,17 +1,17 @@
 'use client'
 
-import { Typography } from '@mui/material'
+import { Typography, Stack } from '@mui/material'
 import TeamInfoContainer from './panel/TeamInfoContainer'
 
 const TeamsPage = ({ params }: { params: { id: string } }) => {
   const { id } = params
 
   return (
-    <>
-      {/* 뒤로가기 기능 추가하기 */}
-      <Typography>팀리스트로 돌아가기</Typography>
+    <Stack>
+      {/* 팀 리스트로 가는 기능 추가하기 */}
+      <Typography sx={{ color: '#9B9B9B' }}>팀리스트로 돌아가기</Typography>
       <TeamInfoContainer id={Number(id)} />
-    </>
+    </Stack>
   )
 }
 

--- a/src/app/teams/@main/[id]/panel/TeamInfoComponent.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoComponent.tsx
@@ -1,0 +1,83 @@
+import { Chip, Stack, Typography } from '@mui/material'
+import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined'
+import PermContactCalendarOutlinedIcon from '@mui/icons-material/PermContactCalendarOutlined'
+import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined'
+import { TOperationForm, TTeamStatus, TTeamType } from '@/types/ITeamInfo'
+
+export const StatusIcon = ({ status }: { status: TTeamStatus }) => {
+  // TODO : 디자인 확정되지 않음
+  switch (status) {
+    case 'RECRUITING':
+      return <Chip label={'모집 중'} sx={{ backgroundColor: '#FFFBDB' }} />
+    case 'BEFORE':
+      return <Chip label={'시작 전'} sx={{ backgroundColor: '#B5B5B5' }} />
+    case 'ONGOING':
+      return <Chip label={'진행 중'} sx={{ backgroundColor: '#EADFFF' }} />
+    case 'COMPLETE':
+      return <Chip label={'진행 완료'} sx={{ backgroundColor: '#F7C5C5' }} />
+  }
+}
+
+type TIconType = 'MEMBER' | 'LEADER' | 'DATE'
+
+interface IIconInfoProps {
+  type: TIconType
+  text: string
+  onClick?: () => void
+}
+
+export const IconInfo = ({ type, text, onClick }: IIconInfoProps) => {
+  switch (type) {
+    case 'MEMBER':
+      return (
+        <Stack direction={'row'} onClick={onClick} sx={{ cursor: 'pointer' }}>
+          <GroupsOutlinedIcon />
+          <Typography>{text}</Typography>
+        </Stack>
+      )
+    case 'LEADER':
+      return (
+        <Stack direction={'row'}>
+          <PermContactCalendarOutlinedIcon />
+          <Typography>{text}</Typography>
+        </Stack>
+      )
+    case 'DATE':
+      return (
+        <Stack direction={'row'}>
+          <CalendarMonthOutlinedIcon />
+          <Typography>{text}</Typography>
+        </Stack>
+      )
+  }
+}
+
+export const RegionInfo = ({ region }: { region: string }) => {
+  // TODO : 디자인 확정되지 않음
+  return <Chip label={region} />
+}
+
+export const OperationFormInfo = ({
+  operationForm,
+}: {
+  operationForm: TOperationForm
+}) => {
+  // TODO : 디자인 확정되지 않음
+  switch (operationForm) {
+    case 'ONLINE':
+      return <Chip label={'온라인'} />
+    case 'OFFLINE':
+      return <Chip label={'오프라인'} />
+    case 'MIX':
+      return <Chip label={'온/오프라인'} />
+  }
+}
+export const TypeInfo = ({ type }: { type: TTeamType }) => {
+  // TODO : 디자인 확정되지 않음
+  switch (type) {
+    case 'PROJECT':
+      return <Chip label={'project'} />
+    case 'STUDY':
+      return <Chip label={'study'} />
+  }
+}

--- a/src/app/teams/@main/[id]/panel/TeamInfoComponent.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoComponent.tsx
@@ -5,7 +5,6 @@ import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined
 import { TOperationForm, TTeamStatus, TTeamType } from '@/types/ITeamInfo'
 
 export const StatusIcon = ({ status }: { status: TTeamStatus }) => {
-  // TODO : 디자인 확정되지 않음
   switch (status) {
     case 'RECRUITING':
       return <Chip label={'모집 중'} sx={{ backgroundColor: '#FFFBDB' }} />
@@ -53,7 +52,6 @@ export const IconInfo = ({ type, text, onClick }: IIconInfoProps) => {
 }
 
 export const RegionInfo = ({ region }: { region: string }) => {
-  // TODO : 디자인 확정되지 않음
   return <Chip label={region} />
 }
 
@@ -62,7 +60,6 @@ export const OperationFormInfo = ({
 }: {
   operationForm: TOperationForm
 }) => {
-  // TODO : 디자인 확정되지 않음
   switch (operationForm) {
     case 'ONLINE':
       return <Chip label={'온라인'} />
@@ -73,7 +70,6 @@ export const OperationFormInfo = ({
   }
 }
 export const TypeInfo = ({ type }: { type: TTeamType }) => {
-  // TODO : 디자인 확정되지 않음
   switch (type) {
     case 'PROJECT':
       return <Chip label={'project'} />

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -6,7 +6,7 @@ import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined
 // import { defaultGetFetcher } from '@/api/fetchers'
 import {
   ITeamInfo,
-  //   TOperationForm,
+  TOperationForm,
   //   TTeamType,
   TTeamStatus,
 } from '@/types/ITeamInfo'
@@ -78,6 +78,22 @@ const RegionInfo = ({ region }: IRegionInfoProps) => {
   return <Chip label={region} />
 }
 
+interface IOperationFormInfoProps {
+  operationForm: TOperationForm
+}
+
+const OperationFormInfo = ({ operationForm }: IOperationFormInfoProps) => {
+  // TODO : 디자인 확정되지 않음
+  switch (operationForm) {
+    case 'ONLINE':
+      return <Chip label={'온라인'} />
+    case 'OFFLINE':
+      return <Chip label={'오프라인'} />
+    case 'MIX':
+      return <Chip label={'온/오프라인'} />
+  }
+}
+
 const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   // TODO : id를 이용해서 데이터 받아오기
   //   const { data, error, isLoading } = useSWR<ITeamInfo>(
@@ -129,7 +145,7 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
       <IconInfo type="LEADER" text={data.leaderName} />
       <Typography>{data.type}</Typography>
       <IconInfo type="DATE" text={data.dueTo.toString()} />
-      <Typography>{data.operationForm}</Typography>
+      <OperationFormInfo operationForm={data.operationForm} />
       <Stack direction={'row'}>
         {data.region.map((region, idx) => (
           <RegionInfo key={idx} region={region} />

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -9,6 +9,7 @@ import {
   TOperationForm,
   TTeamType,
   TTeamStatus,
+  ITeamMember,
 } from '@/types/ITeamInfo'
 import CuModal from '@/components/CuModal'
 import useModal from '@/hook/useModal'
@@ -122,15 +123,63 @@ const TeamMemberModal = ({
   handleClose,
 }: ITeamMemberModalProps) => {
   // TODO : 팀원 목록 받아오기
+  // const { data, error, isLoading } = useSWR<Array<ITeamMember>>(
+  //   `/api/v1/team/main/member/${teamId}`,
+  //   defaultGetFetcher,
+  // )
   void teamId
+
+  const {
+    data,
+    error,
+    isLoading,
+  }: { data: ITeamMember[]; error: any; isLoading: boolean } = {
+    data: [
+      {
+        id: 1,
+        name: 'qwer',
+        role: 'LEADER',
+      },
+      {
+        id: 2,
+        name: 'asdf',
+        role: 'MEMBER',
+      },
+    ],
+    error: false,
+    isLoading: false,
+  }
+
+  // render 1 : 로딩중
+  if (isLoading) {
+    // 로딩 컴포넌트 구체화
+    return <div>로딩중</div>
+  }
+
+  // render 2 : 에러
+  if (error || !data) {
+    // 에러 컴포넌트 구체화
+    // 에러 알림?!
+    return <div>에러!</div>
+  }
+
+  // render 3 : 정상
   return (
+    // TODO: 디자인 확정되지 않음
     <CuModal
       open={open}
       handleClose={handleClose}
       ariaTitle={'팀원 목록'}
       ariaDescription={'팀원 목록을 확인할 수 있습니다.'}
     >
-      헤이헤이헤이
+      <Stack spacing={1}>
+        {data.map((member) => (
+          <Stack key={member.id}>
+            <Typography>name: {member.name}</Typography>
+            <Typography>role: {member.role.toLowerCase()}</Typography>
+          </Stack>
+        ))}
+      </Stack>
     </CuModal>
   )
 }

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -10,6 +10,8 @@ import {
   TTeamType,
   TTeamStatus,
 } from '@/types/ITeamInfo'
+import CuModal from '@/components/CuModal'
+import useModal from '@/hook/useModal'
 
 interface ITeamInfoContainerProps {
   id: number
@@ -40,14 +42,14 @@ type TIconType = 'MEMBER' | 'LEADER' | 'DATE'
 interface IIconInfoProps {
   type: TIconType
   text: string
-  // clickHandler가 필요하면 추가
+  onClick?: () => void
 }
 
-const IconInfo = ({ type, text }: IIconInfoProps) => {
+const IconInfo = ({ type, text, onClick }: IIconInfoProps) => {
   switch (type) {
     case 'MEMBER':
       return (
-        <Stack direction={'row'}>
+        <Stack direction={'row'} onClick={onClick} sx={{ cursor: 'pointer' }}>
           <GroupsOutlinedIcon />
           <Typography>{text}</Typography>
         </Stack>
@@ -108,7 +110,33 @@ const TypeInfo = ({ type }: ITypeInfoProps) => {
   }
 }
 
+interface ITeamMemberModalProps {
+  teamId: number
+  open: boolean
+  handleClose: () => void
+}
+
+const TeamMemberModal = ({
+  teamId,
+  open,
+  handleClose,
+}: ITeamMemberModalProps) => {
+  // TODO : 팀원 목록 받아오기
+  void teamId
+  return (
+    <CuModal
+      open={open}
+      handleClose={handleClose}
+      ariaTitle={'팀원 목록'}
+      ariaDescription={'팀원 목록을 확인할 수 있습니다.'}
+    >
+      헤이헤이헤이
+    </CuModal>
+  )
+}
+
 const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
+  const { isOpen, closeModal, openModal } = useModal()
   // TODO : id를 이용해서 데이터 받아오기
   //   const { data, error, isLoading } = useSWR<ITeamInfo>(
   //     `${process.env.NEXT_PUBLIC_API_URL}/api/v1/team/main/${id}`,
@@ -148,34 +176,45 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   }
   // render 3 : 정상
   return (
-    <Stack direction={'row'} spacing={1}>
-      <Avatar
-        alt="team logo"
-        variant="rounded"
-        sx={{ width: 89, height: 92, border: 1, borderRadius: 1.2 }}
-        src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
-      />
-      <Stack>
-        <Stack direction={'row'}>
-          <Typography variant="h5">{data.name}</Typography>
-          <StatusIcon status={data.status} />
-        </Stack>
-        <Stack direction={'row'}>
-          <IconInfo type="MEMBER" text={data.memberCount} />
-          <IconInfo type="LEADER" text={data.leaderName} />
-          <IconInfo type="DATE" text={data.dueTo.toString()} />
-        </Stack>
-        <Stack direction={'row'}>
-          <TypeInfo type={data.type} />
-          <OperationFormInfo operationForm={data.operationForm} />
-        </Stack>
-        <Stack direction={'row'}>
-          {data.region.map((region, idx) => (
-            <RegionInfo key={idx} region={region} />
-          ))}
+    <>
+      <Stack direction={'row'} spacing={1}>
+        <Avatar
+          alt="team logo"
+          variant="rounded"
+          sx={{ width: 89, height: 92, border: 1, borderRadius: 1.2 }}
+          src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
+        />
+        <Stack>
+          <Stack direction={'row'}>
+            <Typography variant="h5">{data.name}</Typography>
+            <StatusIcon status={data.status} />
+          </Stack>
+          <Stack direction={'row'}>
+            <IconInfo
+              type="MEMBER"
+              text={data.memberCount}
+              onClick={() => openModal()}
+            />
+            <IconInfo type="LEADER" text={data.leaderName} />
+            <IconInfo type="DATE" text={data.dueTo.toString()} />
+          </Stack>
+          <Stack direction={'row'}>
+            <TypeInfo type={data.type} />
+            <OperationFormInfo operationForm={data.operationForm} />
+          </Stack>
+          <Stack direction={'row'}>
+            {data.region.map((region, idx) => (
+              <RegionInfo key={idx} region={region} />
+            ))}
+          </Stack>
         </Stack>
       </Stack>
-    </Stack>
+      <TeamMemberModal
+        teamId={data.id}
+        open={isOpen}
+        handleClose={closeModal}
+      />
+    </>
   )
 
   // 모달 컴포넌트도 추가할 것.

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -22,11 +22,16 @@ interface IStatusIconProps {
 }
 
 const StatusIcon = ({ status }: IStatusIconProps) => {
+  // TODO : 디자인 확정되지 않음
   switch (status) {
     case 'RECRUITING':
-      return <div>모집중</div>
-    default:
-      return <div>아아아</div>
+      return <Chip label={'모집 중'} sx={{ backgroundColor: '#FFFBDB' }} />
+    case 'BEFORE':
+      return <Chip label={'시작 전'} sx={{ backgroundColor: '#B5B5B5' }} />
+    case 'ONGOING':
+      return <Chip label={'진행 중'} sx={{ backgroundColor: '#EADFFF' }} />
+    case 'COMPLETE':
+      return <Chip label={'진행 완료'} sx={{ backgroundColor: '#F7C5C5' }} />
   }
 }
 
@@ -61,8 +66,6 @@ const IconInfo = ({ type, text }: IIconInfoProps) => {
           <Typography>{text}</Typography>
         </Box>
       )
-    // default:
-    //   return <div>아아아</div>
   }
 }
 
@@ -90,7 +93,7 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
       id: id,
       name: '프로젝트 스페이스도그 🐶🚀',
       teamPicturePath: null,
-      status: 'RECRUITING',
+      status: 'BEFORE',
       memberCount: '1/3',
       leaderName: '야채',
       type: 'STUDY',

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -7,7 +7,7 @@ import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined
 import {
   ITeamInfo,
   TOperationForm,
-  //   TTeamType,
+  TTeamType,
   TTeamStatus,
 } from '@/types/ITeamInfo'
 
@@ -94,6 +94,20 @@ const OperationFormInfo = ({ operationForm }: IOperationFormInfoProps) => {
   }
 }
 
+interface ITypeInfoProps {
+  type: TTeamType
+}
+
+const TypeInfo = ({ type }: ITypeInfoProps) => {
+  // TODO : 디자인 확정되지 않음
+  switch (type) {
+    case 'PROJECT':
+      return <Chip label={'project'} />
+    case 'STUDY':
+      return <Chip label={'study'} />
+  }
+}
+
 const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   // TODO : id를 이용해서 데이터 받아오기
   //   const { data, error, isLoading } = useSWR<ITeamInfo>(
@@ -150,7 +164,7 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
           <IconInfo type="DATE" text={data.dueTo.toString()} />
         </Stack>
         <Stack direction={'row'}>
-          <Typography>{data.type}</Typography>
+          <TypeInfo type={data.type} />
           <OperationFormInfo operationForm={data.operationForm} />
         </Stack>
         <Stack direction={'row'}>

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -1,5 +1,5 @@
 // import useSWR from 'swr'
-import { Stack, Box, Typography } from '@mui/material'
+import { Stack, Box, Typography, Chip } from '@mui/material'
 import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined'
 import PermContactCalendarOutlinedIcon from '@mui/icons-material/PermContactCalendarOutlined'
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined'
@@ -66,6 +66,15 @@ const IconInfo = ({ type, text }: IIconInfoProps) => {
   }
 }
 
+interface IRegionInfoProps {
+  region: string
+}
+
+const RegionInfo = ({ region }: IRegionInfoProps) => {
+  // TODO : 디자인 확정되지 않음
+  return <Chip label={region} />
+}
+
 const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   // TODO : id를 이용해서 데이터 받아오기
   //   const { data, error, isLoading } = useSWR<ITeamInfo>(
@@ -118,7 +127,11 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
       <Typography>{data.type}</Typography>
       <IconInfo type="DATE" text={data.dueTo.toString()} />
       <Typography>{data.operationForm}</Typography>
-      <Typography>{data.region}</Typography>
+      <Stack direction={'row'}>
+        {data.region.map((region, idx) => (
+          <RegionInfo key={idx} region={region} />
+        ))}
+      </Stack>
     </Stack>
   )
 

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -5,7 +5,7 @@ import {
   ITeamInfo,
   //   TOperationForm,
   //   TTeamType,
-  //   TTeamStatus,
+  TTeamStatus,
 } from '@/types/ITeamInfo'
 
 interface ITeamInfoContainerProps {
@@ -13,6 +13,19 @@ interface ITeamInfoContainerProps {
 }
 
 const defaultLogoPath = '/images/profile.jpeg' // TODO : 기본 로고 path 확인하기
+
+interface IStatusIconProps {
+  status: TTeamStatus
+}
+
+const StatusIcon = ({ status }: IStatusIconProps) => {
+  switch (status) {
+    case 'RECRUITING':
+      return <div>모집중</div>
+    default:
+      return <div>아아아</div>
+  }
+}
 
 const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   // TODO : id를 이용해서 데이터 받아오기
@@ -60,7 +73,7 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
         component="img"
         src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
       />
-      <Typography>{data.status}</Typography>
+      <StatusIcon status={data.status} />
       <Typography>{data.memberCount}</Typography>
       <Typography>{data.leaderName}</Typography>
       <Typography>{data.type}</Typography>

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -47,24 +47,24 @@ const IconInfo = ({ type, text }: IIconInfoProps) => {
   switch (type) {
     case 'MEMBER':
       return (
-        <Box>
+        <Stack direction={'row'}>
           <GroupsOutlinedIcon />
           <Typography>{text}</Typography>
-        </Box>
+        </Stack>
       )
     case 'LEADER':
       return (
-        <Box>
+        <Stack direction={'row'}>
           <PermContactCalendarOutlinedIcon />
           <Typography>{text}</Typography>
-        </Box>
+        </Stack>
       )
     case 'DATE':
       return (
-        <Box>
+        <Stack direction={'row'}>
           <CalendarMonthOutlinedIcon />
           <Typography>{text}</Typography>
-        </Box>
+        </Stack>
       )
   }
 }
@@ -134,22 +134,30 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   }
   // render 3 : 정상
   return (
-    <Stack>
-      <Typography>{data.name}</Typography>
+    <Stack direction={'row'} spacing={1}>
       <Box
         component="img"
         src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
       />
-      <StatusIcon status={data.status} />
-      <IconInfo type="MEMBER" text={data.memberCount} />
-      <IconInfo type="LEADER" text={data.leaderName} />
-      <Typography>{data.type}</Typography>
-      <IconInfo type="DATE" text={data.dueTo.toString()} />
-      <OperationFormInfo operationForm={data.operationForm} />
-      <Stack direction={'row'}>
-        {data.region.map((region, idx) => (
-          <RegionInfo key={idx} region={region} />
-        ))}
+      <Stack>
+        <Stack direction={'row'}>
+          <Typography variant="h5">{data.name}</Typography>
+          <StatusIcon status={data.status} />
+        </Stack>
+        <Stack direction={'row'}>
+          <IconInfo type="MEMBER" text={data.memberCount} />
+          <IconInfo type="LEADER" text={data.leaderName} />
+          <IconInfo type="DATE" text={data.dueTo.toString()} />
+        </Stack>
+        <Stack direction={'row'}>
+          <Typography>{data.type}</Typography>
+          <OperationFormInfo operationForm={data.operationForm} />
+        </Stack>
+        <Stack direction={'row'}>
+          {data.region.map((region, idx) => (
+            <RegionInfo key={idx} region={region} />
+          ))}
+        </Stack>
       </Stack>
     </Stack>
   )

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -1,5 +1,5 @@
 // import useSWR from 'swr'
-import { Stack, Box, Typography, Chip } from '@mui/material'
+import { Avatar, Stack, Typography, Chip } from '@mui/material'
 import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined'
 import PermContactCalendarOutlinedIcon from '@mui/icons-material/PermContactCalendarOutlined'
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined'
@@ -149,8 +149,10 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
   // render 3 : 정상
   return (
     <Stack direction={'row'} spacing={1}>
-      <Box
-        component="img"
+      <Avatar
+        alt="team logo"
+        variant="rounded"
+        sx={{ width: 89, height: 92, border: 1, borderRadius: 1.2 }}
         src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
       />
       <Stack>

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -1,196 +1,28 @@
 // import useSWR from 'swr'
-import { Avatar, Stack, Typography, Chip } from '@mui/material'
-import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined'
-import PermContactCalendarOutlinedIcon from '@mui/icons-material/PermContactCalendarOutlined'
-import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined'
+import { Avatar, Stack, Typography } from '@mui/material'
 // import { defaultGetFetcher } from '@/api/fetchers'
-import {
-  ITeamInfo,
-  TOperationForm,
-  TTeamType,
-  TTeamStatus,
-  ITeamMember,
-} from '@/types/ITeamInfo'
-import CuModal from '@/components/CuModal'
+import { ITeamInfo } from '@/types/ITeamInfo'
 import useModal from '@/hook/useModal'
-
-interface ITeamInfoContainerProps {
-  id: number
-}
+import {
+  StatusIcon,
+  IconInfo,
+  RegionInfo,
+  OperationFormInfo,
+  TypeInfo,
+} from './TeamInfoComponent'
+import TeamMemberModal from './TeamMemberModal'
 
 const defaultLogoPath = '/images/profile.jpeg' // TODO : 기본 로고 path 확인하기
 
-interface IStatusIconProps {
-  status: TTeamStatus
-}
-
-const StatusIcon = ({ status }: IStatusIconProps) => {
-  // TODO : 디자인 확정되지 않음
-  switch (status) {
-    case 'RECRUITING':
-      return <Chip label={'모집 중'} sx={{ backgroundColor: '#FFFBDB' }} />
-    case 'BEFORE':
-      return <Chip label={'시작 전'} sx={{ backgroundColor: '#B5B5B5' }} />
-    case 'ONGOING':
-      return <Chip label={'진행 중'} sx={{ backgroundColor: '#EADFFF' }} />
-    case 'COMPLETE':
-      return <Chip label={'진행 완료'} sx={{ backgroundColor: '#F7C5C5' }} />
-  }
-}
-
-type TIconType = 'MEMBER' | 'LEADER' | 'DATE'
-
-interface IIconInfoProps {
-  type: TIconType
-  text: string
-  onClick?: () => void
-}
-
-const IconInfo = ({ type, text, onClick }: IIconInfoProps) => {
-  switch (type) {
-    case 'MEMBER':
-      return (
-        <Stack direction={'row'} onClick={onClick} sx={{ cursor: 'pointer' }}>
-          <GroupsOutlinedIcon />
-          <Typography>{text}</Typography>
-        </Stack>
-      )
-    case 'LEADER':
-      return (
-        <Stack direction={'row'}>
-          <PermContactCalendarOutlinedIcon />
-          <Typography>{text}</Typography>
-        </Stack>
-      )
-    case 'DATE':
-      return (
-        <Stack direction={'row'}>
-          <CalendarMonthOutlinedIcon />
-          <Typography>{text}</Typography>
-        </Stack>
-      )
-  }
-}
-
-interface IRegionInfoProps {
-  region: string
-}
-
-const RegionInfo = ({ region }: IRegionInfoProps) => {
-  // TODO : 디자인 확정되지 않음
-  return <Chip label={region} />
-}
-
-interface IOperationFormInfoProps {
-  operationForm: TOperationForm
-}
-
-const OperationFormInfo = ({ operationForm }: IOperationFormInfoProps) => {
-  // TODO : 디자인 확정되지 않음
-  switch (operationForm) {
-    case 'ONLINE':
-      return <Chip label={'온라인'} />
-    case 'OFFLINE':
-      return <Chip label={'오프라인'} />
-    case 'MIX':
-      return <Chip label={'온/오프라인'} />
-  }
-}
-
-interface ITypeInfoProps {
-  type: TTeamType
-}
-
-const TypeInfo = ({ type }: ITypeInfoProps) => {
-  // TODO : 디자인 확정되지 않음
-  switch (type) {
-    case 'PROJECT':
-      return <Chip label={'project'} />
-    case 'STUDY':
-      return <Chip label={'study'} />
-  }
-}
-
-interface ITeamMemberModalProps {
-  teamId: number
-  open: boolean
-  handleClose: () => void
-}
-
-const TeamMemberModal = ({
-  teamId,
-  open,
-  handleClose,
-}: ITeamMemberModalProps) => {
-  // TODO : 팀원 목록 받아오기
-  // const { data, error, isLoading } = useSWR<Array<ITeamMember>>(
-  //   `/api/v1/team/main/member/${teamId}`,
-  //   defaultGetFetcher,
-  // )
-  void teamId
-
-  const {
-    data,
-    error,
-    isLoading,
-  }: { data: ITeamMember[]; error: any; isLoading: boolean } = {
-    data: [
-      {
-        id: 1,
-        name: 'qwer',
-        role: 'LEADER',
-      },
-      {
-        id: 2,
-        name: 'asdf',
-        role: 'MEMBER',
-      },
-    ],
-    error: false,
-    isLoading: false,
-  }
-
-  // render 1 : 로딩중
-  if (isLoading) {
-    // 로딩 컴포넌트 구체화
-    return <div>로딩중</div>
-  }
-
-  // render 2 : 에러
-  if (error || !data) {
-    // 에러 컴포넌트 구체화
-    // 에러 알림?!
-    return <div>에러!</div>
-  }
-
-  // render 3 : 정상
-  return (
-    // TODO: 디자인 확정되지 않음
-    <CuModal
-      open={open}
-      handleClose={handleClose}
-      ariaTitle={'팀원 목록'}
-      ariaDescription={'팀원 목록을 확인할 수 있습니다.'}
-    >
-      <Stack spacing={1}>
-        {data.map((member) => (
-          <Stack key={member.id}>
-            <Typography>name: {member.name}</Typography>
-            <Typography>role: {member.role.toLowerCase()}</Typography>
-          </Stack>
-        ))}
-      </Stack>
-    </CuModal>
-  )
-}
-
-const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
+const TeamInfoContainer = ({ id }: { id: number }) => {
   const { isOpen, closeModal, openModal } = useModal()
   // TODO : id를 이용해서 데이터 받아오기
   //   const { data, error, isLoading } = useSWR<ITeamInfo>(
   //     `${process.env.NEXT_PUBLIC_API_URL}/api/v1/team/main/${id}`,
   //     defaultGetFetcher,
   //   )
+
+  // Mock Data
   const {
     data,
     error,

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -1,5 +1,8 @@
 // import useSWR from 'swr'
 import { Stack, Box, Typography } from '@mui/material'
+import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined'
+import PermContactCalendarOutlinedIcon from '@mui/icons-material/PermContactCalendarOutlined'
+import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined'
 // import { defaultGetFetcher } from '@/api/fetchers'
 import {
   ITeamInfo,
@@ -24,6 +27,42 @@ const StatusIcon = ({ status }: IStatusIconProps) => {
       return <div>모집중</div>
     default:
       return <div>아아아</div>
+  }
+}
+
+type TIconType = 'MEMBER' | 'LEADER' | 'DATE'
+
+interface IIconInfoProps {
+  type: TIconType
+  text: string
+  // clickHandler가 필요하면 추가
+}
+
+const IconInfo = ({ type, text }: IIconInfoProps) => {
+  switch (type) {
+    case 'MEMBER':
+      return (
+        <Box>
+          <GroupsOutlinedIcon />
+          <Typography>{text}</Typography>
+        </Box>
+      )
+    case 'LEADER':
+      return (
+        <Box>
+          <PermContactCalendarOutlinedIcon />
+          <Typography>{text}</Typography>
+        </Box>
+      )
+    case 'DATE':
+      return (
+        <Box>
+          <CalendarMonthOutlinedIcon />
+          <Typography>{text}</Typography>
+        </Box>
+      )
+    // default:
+    //   return <div>아아아</div>
   }
 }
 
@@ -74,10 +113,10 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
         src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
       />
       <StatusIcon status={data.status} />
-      <Typography>{data.memberCount}</Typography>
-      <Typography>{data.leaderName}</Typography>
+      <IconInfo type="MEMBER" text={data.memberCount} />
+      <IconInfo type="LEADER" text={data.leaderName} />
       <Typography>{data.type}</Typography>
-      <Typography>{data.dueTo}</Typography>
+      <IconInfo type="DATE" text={data.dueTo.toString()} />
       <Typography>{data.operationForm}</Typography>
       <Typography>{data.region}</Typography>
     </Stack>

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -44,18 +44,15 @@ const TeamInfoContainer = ({ id }: { id: number }) => {
     isLoading: false,
   }
 
-  // render 1 : 로딩중
   if (isLoading) {
-    // 로딩 컴포넌트 구체화
-    return <div>로딩중</div>
+    return <Typography>로딩중...</Typography>
   }
-  // render 2 : 에러
+
   if (error || !data) {
-    // 에러 컴포넌트 구체화
-    // 에러 알림?!
-    return <div>에러!</div>
+    // TODO : 에러 종류에 따라 에러 메시지 다르게 표시
+    return <Typography>에러!!!</Typography>
   }
-  // render 3 : 정상
+
   return (
     <>
       <Stack direction={'row'} spacing={1}>

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -1,0 +1,69 @@
+// import useSWR from 'swr'
+import { Stack, Box, Typography } from '@mui/material'
+// import { defaultGetFetcher } from '@/api/fetchers'
+import {
+  ITeamInfo,
+  //   TOperationForm,
+  //   TTeamType,
+  //   TTeamStatus,
+} from '@/types/ITeamInfo'
+
+interface ITeamInfoContainerProps {
+  id: number
+}
+
+const defaultLogoPath = '/images/profile.jpeg' // TODO : 기본 로고 path 확인하기
+
+const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
+  // TODO : id를 이용해서 데이터 받아오기
+  //   const { data, error, isLoading } = useSWR<ITeamInfo>(
+  //     `${process.env.NEXT_PUBLIC_API_URL}/api/v1/team/main/${id}`,
+  //     defaultGetFetcher,
+  //   )
+  const {
+    data,
+    error,
+    isLoading,
+  }: { data: ITeamInfo; error: any; isLoading: boolean } = {
+    data: {
+      id: id,
+      name: '프로젝트 스페이스도그 🐶🚀',
+      teamPicturePath: null,
+      status: 'RECRUITING',
+      memberCount: '1/3',
+      leaderName: '야채',
+      type: 'STUDY',
+      dueTo: 12,
+      operationForm: 'ONLINE',
+      region: ['서울', '인천'],
+    },
+    error: false,
+    isLoading: false,
+  }
+
+  // render 1 : 로딩중
+  if (isLoading) {
+    // 로딩 컴포넌트 구체화
+    return <div>로딩중</div>
+  }
+  // render 2 : 에러
+  if (error || !data) {
+    // 에러 컴포넌트 구체화
+    // 에러 알림?!
+    return <div>에러!</div>
+  }
+  // render 3 : 정상
+  return (
+    <Stack>
+      <Typography>{data.name}</Typography>
+      <Box
+        component="img"
+        src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
+      />
+    </Stack>
+  )
+
+  // 모달 컴포넌트도 추가할 것.
+}
+
+export default TeamInfoContainer

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -60,6 +60,13 @@ const TeamInfoContainer = ({ id }: ITeamInfoContainerProps) => {
         component="img"
         src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
       />
+      <Typography>{data.status}</Typography>
+      <Typography>{data.memberCount}</Typography>
+      <Typography>{data.leaderName}</Typography>
+      <Typography>{data.type}</Typography>
+      <Typography>{data.dueTo}</Typography>
+      <Typography>{data.operationForm}</Typography>
+      <Typography>{data.region}</Typography>
     </Stack>
   )
 

--- a/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamInfoContainer.tsx
@@ -97,8 +97,6 @@ const TeamInfoContainer = ({ id }: { id: number }) => {
       />
     </>
   )
-
-  // 모달 컴포넌트도 추가할 것.
 }
 
 export default TeamInfoContainer

--- a/src/app/teams/@main/[id]/panel/TeamMemberModal.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamMemberModal.tsx
@@ -1,0 +1,78 @@
+import { Stack, Typography } from '@mui/material'
+import CuModal from '@/components/CuModal'
+import { ITeamMember } from '@/types/ITeamInfo'
+
+interface ITeamMemberModalProps {
+  teamId: number
+  open: boolean
+  handleClose: () => void
+}
+const TeamMemberModal = ({
+  teamId,
+  open,
+  handleClose,
+}: ITeamMemberModalProps) => {
+  // TODO : 팀원 목록 받아오기
+  // const { data, error, isLoading } = useSWR<Array<ITeamMember>>(
+  //   `/api/v1/team/main/member/${teamId}`,
+  //   defaultGetFetcher,
+  // )
+  void teamId // no unused var error 방지
+
+  // Mock Data
+  const {
+    data,
+    error,
+    isLoading,
+  }: { data: ITeamMember[]; error: any; isLoading: boolean } = {
+    data: [
+      {
+        id: 1,
+        name: 'qwer',
+        role: 'LEADER',
+      },
+      {
+        id: 2,
+        name: 'asdf',
+        role: 'MEMBER',
+      },
+    ],
+    error: false,
+    isLoading: false,
+  }
+
+  // render 1 : 로딩중
+  if (isLoading) {
+    // 로딩 컴포넌트 구체화
+    return <div>로딩중</div>
+  }
+
+  // render 2 : 에러
+  if (error || !data) {
+    // 에러 컴포넌트 구체화
+    // 에러 알림?!
+    return <div>에러!</div>
+  }
+
+  // render 3 : 정상
+  return (
+    // TODO: 디자인 확정되지 않음
+    <CuModal
+      open={open}
+      handleClose={handleClose}
+      ariaTitle={'팀원 목록'}
+      ariaDescription={'팀원 목록을 확인할 수 있습니다.'}
+    >
+      <Stack spacing={1}>
+        {data.map((member) => (
+          <Stack key={member.id}>
+            <Typography>name: {member.name}</Typography>
+            <Typography>role: {member.role.toLowerCase()}</Typography>
+          </Stack>
+        ))}
+      </Stack>
+    </CuModal>
+  )
+}
+
+export default TeamMemberModal

--- a/src/app/teams/@main/[id]/panel/TeamMemberModal.tsx
+++ b/src/app/teams/@main/[id]/panel/TeamMemberModal.tsx
@@ -14,7 +14,7 @@ const TeamMemberModal = ({
 }: ITeamMemberModalProps) => {
   // TODO : 팀원 목록 받아오기
   // const { data, error, isLoading } = useSWR<Array<ITeamMember>>(
-  //   `/api/v1/team/main/member/${teamId}`,
+  //   `${process.env.NEXT_PUBLIC_API_URL}/api/v1/team/main/member/${teamId}`,
   //   defaultGetFetcher,
   // )
   void teamId // no unused var error 방지
@@ -41,22 +41,16 @@ const TeamMemberModal = ({
     isLoading: false,
   }
 
-  // render 1 : 로딩중
   if (isLoading) {
-    // 로딩 컴포넌트 구체화
-    return <div>로딩중</div>
+    return <Typography>로딩중...</Typography>
   }
 
-  // render 2 : 에러
   if (error || !data) {
-    // 에러 컴포넌트 구체화
-    // 에러 알림?!
-    return <div>에러!</div>
+    // TODO : 에러 종류에 따라 에러 메시지 다르게 표시
+    return <Typography>에러!!!</Typography>
   }
 
-  // render 3 : 정상
   return (
-    // TODO: 디자인 확정되지 않음
     <CuModal
       open={open}
       handleClose={handleClose}

--- a/src/types/ITeamInfo.ts
+++ b/src/types/ITeamInfo.ts
@@ -1,0 +1,18 @@
+export type TTeamStatus = 'RECRUITING' // TODO : 타입 추가
+
+export type TTeamType = 'STUDY' // TODO : 타입 추가
+
+export type TOperationForm = 'ONLINE' | 'OFFLINE'
+
+export interface ITeamInfo {
+  id: number
+  name: string
+  teamPicturePath: string | null // 설정된 프로필 이미지가 없는 경우 null
+  status: TTeamStatus
+  memberCount: string // "현재 팀원 / 최대 팀원" 형식
+  leaderName: string
+  type: TTeamType
+  dueTo: number
+  operationForm: TOperationForm
+  region: string[]
+}

--- a/src/types/ITeamInfo.ts
+++ b/src/types/ITeamInfo.ts
@@ -16,3 +16,11 @@ export interface ITeamInfo {
   operationForm: TOperationForm
   region: string[]
 }
+
+export type TTeamRole = 'LEADER' | 'MEMBER'
+
+export interface ITeamMember {
+  id: number
+  name: string
+  role: TTeamRole
+}

--- a/src/types/ITeamInfo.ts
+++ b/src/types/ITeamInfo.ts
@@ -1,8 +1,8 @@
-export type TTeamStatus = 'RECRUITING' // TODO : 타입 추가
+export type TTeamStatus = 'RECRUITING' | 'BEFORE' | 'ONGOING' | 'COMPLETE'
 
-export type TTeamType = 'STUDY' // TODO : 타입 추가
+export type TTeamType = 'STUDY' | 'PROJECT'
 
-export type TOperationForm = 'ONLINE' | 'OFFLINE'
+export type TOperationForm = 'ONLINE' | 'OFFLINE' | 'MIX'
 
 export interface ITeamInfo {
   id: number


### PR DESCRIPTION
`/teams/[id]` 페이지 중 DnD를 제외한 부분을 추가했습니다.

### 구현사항

- 받아온 팀 정보를 확인할 수 있습니다. (와이어프레임이 아직 확정되지 않아서 임의로 적용해두었습니다.)
- 팀원 수 정보를 눌러서 참여 중인 팀원의 정보 모달을 띄울 수 있습니다.
- api 요청을 확인해볼수가 없어서 mock data로 적용해두었습니다.

<img width="40%" alt="Screen_Shot 2023-10-27 17 58 12" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/d87e77b4-a7f3-45cc-a81e-f401c45d85fa">
<img width="40%" alt="Screen_Shot 2023-10-27 18 02 50" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0588b7f4-9365-4583-8ca0-c523d7692011">

### 추가 작업 예정 사항

- 와이어프레임 확정되면 컴포넌트 배치하기
- api 연동하기