### PR TITLE
[B-INFO] 인증코드 타이머 추가

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -14,6 +14,7 @@ import PasswordField from './panel/PasswordField'
 import NameField from './panel/NameField'
 import NickNameField from './panel/NickNameField'
 import { ISignUpInputs } from '@/types/ISignUpInputs'
+// import useToast from '@/hook/useToast'
 
 const mainStyle = {
   display: 'flex',
@@ -51,7 +52,6 @@ const SignUp = () => {
   const {
     handleSubmit,
     control,
-
     formState: { errors },
     getValues,
   } = useForm<ISignUpInputs>({
@@ -75,13 +75,13 @@ const SignUp = () => {
   const [nickNameSendStatus, setNickNameSendStatus] = useState<
     'before' | 'submit' | 'error'
   >('before')
-
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+  // const { CuToast, isOpen, openToast, closeToast } = useToast()
 
   const submitEmail = async () => {
     setIsSubmitting(true)
     const email = getValues('email')
-    if (email === '' || errors.email?.message) {
+    if (email === '' || errors.email) {
       alert('이메일을 확인해주세요') // 토스트로 바꿔줄 예정
       setIsSubmitting(false)
       return
@@ -114,7 +114,7 @@ const SignUp = () => {
     }
     const email = getValues('email')
     const code = getValues('code')
-    if (code === '' || errors.code?.message) {
+    if (code === '' || errors.code) {
       alert('인증코드를 확인해주세요') // 토스트로 바꿔줄 예정
       setIsSubmitting(false)
       return
@@ -141,8 +141,7 @@ const SignUp = () => {
   const clickNext = () => {
     setIsSubmitting(true)
     const password = getValues('password')
-    console.log(errors.password?.message)
-    if (password === '' || errors.password?.message) {
+    if (password === '' || errors.password) {
       alert('비밀번호를 확인해주세요') // 토스트로 바꿔줄 예정
       setIsSubmitting(false)
       return
@@ -157,7 +156,6 @@ const SignUp = () => {
       setIsSubmitting(false)
       return
     }
-
     setSignUpStep(1)
     setIsSubmitting(false)
   }
@@ -165,7 +163,7 @@ const SignUp = () => {
   const submitNickName = async () => {
     setIsSubmitting(true)
     const nickName = getValues('nickName')
-    if (nickName === undefined || errors.nickName?.message) {
+    if (nickName === undefined || errors.nickName) {
       alert('닉네임을 확인해주세요') // 토스트로 바꿔줄 예정
       setIsSubmitting(false)
       return
@@ -220,140 +218,149 @@ const SignUp = () => {
   }
 
   return (
-    <Box sx={mainStyle} component="main">
-      <Typography
-        aria-label="회원가입"
-        sx={{ textAlign: 'center', flexGrow: 1 }}
-        component="h3"
-      >
-        회원가입
-      </Typography>
-      <form onSubmit={handleSubmit(submitSignUp)}>
-        <Box sx={formStyle}>
-          {signUpStep === 0 && (
-            <>
-              <Controller
-                name="email"
-                control={control}
-                rules={{
-                  required: '이메일을 입력하세요',
-                  pattern: {
-                    value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
-                    message: '유효한 이메일 형식이 아닙니다',
-                  },
-                }}
-                render={({ field }) => (
-                  <EmailField
-                    field={field}
-                    emailSendStatus={emailSendStatus}
-                    setEmailSendStatus={setEmailSendStatus}
-                    submitEmail={submitEmail}
-                    isSubmitting={isSubmitting}
-                    error={errors?.email}
-                  />
-                )}
-              />
-              <Controller
-                name="code"
-                control={control}
-                rules={{
-                  required: '인증코드를 입력하세요',
-                }}
-                render={({ field }) => (
-                  <CodeField
-                    field={field}
-                    codeSendStatus={codeSendStatus}
-                    setCodeSendStatus={setCodeSendStatus}
-                    submitCode={submitCode}
-                    isSubmitting={isSubmitting}
-                    error={errors?.code}
-                  />
-                )}
-              />
-              <Controller
-                name="password"
-                control={control}
-                rules={{
-                  required: '비밀번호를 입력하세요',
-                  validate: {
-                    minLength: (value) =>
-                      value.length >= 8 || '비밀번호는 8자 이상이어야 합니다',
-                    includeNumber: (value) =>
-                      /\d/.test(value) || '숫자를 포함해야 합니다',
-                    includeSpecial: (value) =>
-                      /[~!@#$%^&*<>]/.test(value) ||
-                      '특수문자를 포함해야 합니다',
-                    includeAlphabet: (value) =>
-                      (/[A-Z]/.test(value) && /[a-z]/.test(value)) ||
-                      '대소문자를 포함해야 합니다',
-                  },
-                }}
-                render={({ field }) => <PasswordField field={field} />}
-              />
-              <Button
-                sx={nextButtonStyle}
-                variant="contained"
-                onClick={clickNext}
-                disabled={isSubmitting}
-              >
-                다음
-              </Button>
-            </>
-          )}
-          {signUpStep === 1 && (
-            <>
-              <Controller
-                name="name"
-                control={control}
-                rules={{
-                  required: '이름을 입력하세요',
-                  pattern: {
-                    value: /^[가-힣]{2,4}$/i,
-                    message: '한글 2 ~ 4자로 입력하세요',
-                  },
-                }}
-                render={({ field }) => (
-                  <NameField field={field} error={errors?.name} />
-                )}
-              />
-              <Controller
-                name="nickName"
-                control={control}
-                rules={{
-                  required: '닉네임을 입력하세요',
-                  minLength: {
-                    value: 2,
-                    message: '닉네임은 2자 이상이어야 합니다',
-                  },
-                  maxLength: {
-                    value: 7,
-                    message: '닉네임은 7자 이하여야 합니다',
-                  },
-                }}
-                render={({ field }) => (
-                  <NickNameField
-                    field={field}
-                    nickNameSendStatus={nickNameSendStatus}
-                    setNickNameSendStatus={setNickNameSendStatus}
-                    submitNickName={submitNickName}
-                    isSubmitting={isSubmitting}
-                    error={errors?.nickName}
-                  />
-                )}
-              />
-              <Button
-                sx={buttonStyle}
-                type="submit"
-                variant="contained"
-                disabled={isSubmitting}
-              >
-                가입하기
-              </Button>
-            </>
-          )}
-        </Box>
-      </form>
-    </Box>
+    <>
+      <Box sx={mainStyle} component="main">
+        <Typography
+          aria-label="회원가입"
+          sx={{ textAlign: 'center', flexGrow: 1 }}
+          component="h3"
+        >
+          회원가입
+        </Typography>
+        <form onSubmit={handleSubmit(submitSignUp)}>
+          <Box sx={formStyle}>
+            {signUpStep === 0 && (
+              <>
+                <Controller
+                  name="email"
+                  control={control}
+                  rules={{
+                    required: '이메일을 입력하세요',
+                    pattern: {
+                      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
+                      message: '유효한 이메일 형식이 아닙니다',
+                    },
+                  }}
+                  render={({ field }) => (
+                    <EmailField
+                      field={field}
+                      emailSendStatus={emailSendStatus}
+                      setEmailSendStatus={setEmailSendStatus}
+                      submitEmail={submitEmail}
+                      isSubmitting={isSubmitting}
+                      error={errors?.email}
+                    />
+                  )}
+                />
+                <Controller
+                  name="code"
+                  control={control}
+                  rules={{
+                    required: '인증코드를 입력하세요',
+                  }}
+                  render={({ field }) => (
+                    <CodeField
+                      field={field}
+                      codeSendStatus={codeSendStatus}
+                      setCodeSendStatus={setCodeSendStatus}
+                      submitCode={submitCode}
+                      isSubmitting={isSubmitting}
+                      error={errors?.code}
+                    />
+                  )}
+                />
+                <Controller
+                  name="password"
+                  control={control}
+                  rules={{
+                    required: '비밀번호를 입력하세요',
+                    validate: {
+                      minLength: (value) =>
+                        value.length >= 8 || '비밀번호는 8자 이상이어야 합니다',
+                      includeNumber: (value) =>
+                        /\d/.test(value) || '숫자를 포함해야 합니다',
+                      includeSpecial: (value) =>
+                        /[~!@#$%^&*<>]/.test(value) ||
+                        '특수문자를 포함해야 합니다',
+                      includeAlphabet: (value) =>
+                        (/[A-Z]/.test(value) && /[a-z]/.test(value)) ||
+                        '대소문자를 포함해야 합니다',
+                    },
+                  }}
+                  render={({ field }) => <PasswordField field={field} />}
+                />
+                <Button
+                  sx={nextButtonStyle}
+                  variant="contained"
+                  onClick={clickNext}
+                  disabled={isSubmitting}
+                >
+                  다음
+                </Button>
+              </>
+            )}
+            {signUpStep === 1 && (
+              <>
+                <Controller
+                  name="name"
+                  control={control}
+                  rules={{
+                    required: '이름을 입력하세요',
+                    pattern: {
+                      value: /^[가-힣]{2,4}$/i,
+                      message: '한글 2 ~ 4자로 입력하세요',
+                    },
+                  }}
+                  render={({ field }) => (
+                    <NameField field={field} error={errors?.name} />
+                  )}
+                />
+                <Controller
+                  name="nickName"
+                  control={control}
+                  rules={{
+                    required: '닉네임을 입력하세요',
+                    minLength: {
+                      value: 2,
+                      message: '닉네임은 2자 이상이어야 합니다',
+                    },
+                    maxLength: {
+                      value: 7,
+                      message: '닉네임은 7자 이하여야 합니다',
+                    },
+                    pattern: {
+                      value: /^[가-힣a-zA-Z0-9]+$/i,
+                      message: '한글, 영문, 숫자만 사용할 수 있습니다',
+                    },
+                  }}
+                  render={({ field }) => (
+                    <NickNameField
+                      field={field}
+                      nickNameSendStatus={nickNameSendStatus}
+                      setNickNameSendStatus={setNickNameSendStatus}
+                      submitNickName={submitNickName}
+                      isSubmitting={isSubmitting}
+                      error={errors?.nickName}
+                    />
+                  )}
+                />
+                <Button
+                  sx={buttonStyle}
+                  type="submit"
+                  variant="contained"
+                  disabled={isSubmitting}
+                >
+                  가입하기
+                </Button>
+              </>
+            )}
+          </Box>
+        </form>
+      </Box>
+      {/* <CuToast open={isOpen} onClose={closeToast} severity="error">
+        <Typography>이미 가입된 이메일입니다</Typography>
+      </CuToast> */}
+    </>
   )
 }
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -245,7 +245,6 @@ const SignUp = () => {
                     <EmailField
                       field={field}
                       emailSendStatus={emailSendStatus}
-                      setEmailSendStatus={setEmailSendStatus}
                       submitEmail={submitEmail}
                       isSubmitting={isSubmitting}
                       error={errors?.email}
@@ -262,7 +261,6 @@ const SignUp = () => {
                     <CodeField
                       field={field}
                       codeSendStatus={codeSendStatus}
-                      setCodeSendStatus={setCodeSendStatus}
                       submitCode={submitCode}
                       isSubmitting={isSubmitting}
                       error={errors?.code}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -69,7 +69,7 @@ const SignUp = () => {
   const [signUpStep, setSignUpStep] = useState<number>(0)
   const [emailSendStatus, setEmailSendStatus] = useState<
     'before' | 'submit' | 'error'
-  >('submit')
+  >('before')
   const [codeSendStatus, setCodeSendStatus] = useState<
     'before' | 'submit' | 'error'
   >('before')

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -145,7 +145,7 @@ const SignUp = () => {
     setIsSubmitting(true)
     const password = getValues('password')
     if (password === '' || errors.password) {
-      return
+      setToastMessage('비밀번호를 확인해주세요')
     } else if (emailSendStatus !== 'submit') {
       setEmailSendStatus('error')
       setToastMessage('이메일을 인증해주세요')
@@ -366,9 +366,10 @@ const SignUp = () => {
         severity={
           emailSendStatus === 'error' ||
           codeSendStatus === 'error' ||
-          nickNameSendStatus === 'error'
+          nickNameSendStatus === 'error' ||
+          toastMessage.includes('확인')
             ? 'error'
-            : 'success'
+            : 'info'
         }
       >
         <Typography>{toastMessage}</Typography>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -14,6 +14,7 @@ import PasswordField from './panel/PasswordField'
 import NameField from './panel/NameField'
 import NickNameField from './panel/NickNameField'
 import { ISignUpInputs } from '@/types/ISignUpInputs'
+import CodeTimer from './panel/CodeTimer'
 // import useToast from '@/hook/useToast'
 
 const mainStyle = {
@@ -68,7 +69,7 @@ const SignUp = () => {
   const [signUpStep, setSignUpStep] = useState<number>(0)
   const [emailSendStatus, setEmailSendStatus] = useState<
     'before' | 'submit' | 'error'
-  >('before')
+  >('submit')
   const [codeSendStatus, setCodeSendStatus] = useState<
     'before' | 'submit' | 'error'
   >('before')
@@ -263,10 +264,13 @@ const SignUp = () => {
                       codeSendStatus={codeSendStatus}
                       submitCode={submitCode}
                       isSubmitting={isSubmitting}
-                      error={errors?.code}
                     />
                   )}
                 />
+                {(emailSendStatus === 'submit' &&
+                  codeSendStatus !== 'submit' && (
+                    <CodeTimer setEmailSendStatus={setEmailSendStatus} />
+                  )) || <Typography>&nbsp;</Typography>}
                 <Controller
                   name="password"
                   control={control}

--- a/src/app/signup/panel/CodeField.tsx
+++ b/src/app/signup/panel/CodeField.tsx
@@ -1,7 +1,7 @@
 import { InputAdornment, Button, Typography } from '@mui/material'
 import CuTextField from '@/components/CuTextField'
 import CuTextFieldLabel from '@/components/CuTextFieldLabel'
-import { ControllerRenderProps, FieldError } from 'react-hook-form'
+import { ControllerRenderProps } from 'react-hook-form'
 import { ISignUpInputs } from '@/types/ISignUpInputs'
 
 const CodeField = ({
@@ -9,13 +9,11 @@ const CodeField = ({
   codeSendStatus,
   submitCode,
   isSubmitting,
-  error,
 }: {
   field: ControllerRenderProps<ISignUpInputs, 'code'>
   codeSendStatus: 'before' | 'submit' | 'error'
   submitCode: () => void
   isSubmitting: boolean
-  error: FieldError | undefined
 }) => {
   return (
     <>
@@ -44,9 +42,6 @@ const CodeField = ({
           ),
         }}
       />
-      {(error && <Typography color="error">{error.message}</Typography>) || (
-        <Typography>&nbsp;</Typography>
-      )}
     </>
   )
 }

--- a/src/app/signup/panel/CodeField.tsx
+++ b/src/app/signup/panel/CodeField.tsx
@@ -1,5 +1,3 @@
-import { Dispatch, SetStateAction } from 'react'
-
 import { InputAdornment, Button, Typography } from '@mui/material'
 import CuTextField from '@/components/CuTextField'
 import CuTextFieldLabel from '@/components/CuTextFieldLabel'
@@ -9,14 +7,12 @@ import { ISignUpInputs } from '@/types/ISignUpInputs'
 const CodeField = ({
   field,
   codeSendStatus,
-  setCodeSendStatus,
   submitCode,
   isSubmitting,
   error,
 }: {
   field: ControllerRenderProps<ISignUpInputs, 'code'>
   codeSendStatus: 'before' | 'submit' | 'error'
-  setCodeSendStatus: Dispatch<SetStateAction<'before' | 'submit' | 'error'>>
   submitCode: () => void
   isSubmitting: boolean
   error: FieldError | undefined
@@ -25,13 +21,8 @@ const CodeField = ({
     <>
       <CuTextFieldLabel htmlFor="code">인증번호</CuTextFieldLabel>
       <CuTextField
-        field={{
-          ...field,
-          onChange: (e: any) => {
-            field.onChange(e)
-            setCodeSendStatus('before')
-          },
-        }}
+        field={field}
+        disabled={codeSendStatus === 'submit'}
         autoComplete="off"
         error={codeSendStatus === 'error'}
         type="text"
@@ -44,7 +35,7 @@ const CodeField = ({
             <InputAdornment position="end">
               <Button
                 variant="contained"
-                disabled={isSubmitting}
+                disabled={isSubmitting || codeSendStatus === 'submit'}
                 onClick={submitCode}
               >
                 인증번호 확인

--- a/src/app/signup/panel/CodeField.tsx
+++ b/src/app/signup/panel/CodeField.tsx
@@ -1,4 +1,4 @@
-import { InputAdornment, Button, Typography } from '@mui/material'
+import { InputAdornment, Button } from '@mui/material'
 import CuTextField from '@/components/CuTextField'
 import CuTextFieldLabel from '@/components/CuTextFieldLabel'
 import { ControllerRenderProps } from 'react-hook-form'

--- a/src/app/signup/panel/CodeTimer.tsx
+++ b/src/app/signup/panel/CodeTimer.tsx
@@ -8,7 +8,7 @@ const CodeTimer = ({
 }: {
   setEmailSendStatus: Dispatch<SetStateAction<'before' | 'submit' | 'error'>>
 }) => {
-  const [timer, setTimer] = useState(5)
+  const [timer, setTimer] = useState(5 * 60)
 
   useEffect(() => {
     const countdown = setInterval(() => {

--- a/src/app/signup/panel/CodeTimer.tsx
+++ b/src/app/signup/panel/CodeTimer.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useState, useEffect, Dispatch, SetStateAction } from 'react'
+import { Typography } from '@mui/material'
+
+const CodeTimer = ({
+  setEmailSendStatus,
+}: {
+  setEmailSendStatus: Dispatch<SetStateAction<'before' | 'submit' | 'error'>>
+}) => {
+  const [timer, setTimer] = useState(5)
+
+  useEffect(() => {
+    const countdown = setInterval(() => {
+      setTimer((prevTimer) => prevTimer - 1)
+    }, 1000)
+
+    return () => {
+      clearInterval(countdown)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (timer === 0) {
+      alert('인증 코드가 만료되었습니다.')
+      setEmailSendStatus('before')
+    }
+  }, [timer, setEmailSendStatus])
+
+  return (
+    <>
+      <Typography>{`${Math.floor(timer / 60)}:${(timer % 60)
+        .toString()
+        .padStart(2, '0')}`}</Typography>
+    </>
+  )
+}
+
+export default CodeTimer

--- a/src/app/signup/panel/EmailField.tsx
+++ b/src/app/signup/panel/EmailField.tsx
@@ -1,5 +1,3 @@
-import { Dispatch, SetStateAction } from 'react'
-
 import { InputAdornment, Button, Typography } from '@mui/material'
 import CuTextField from '@/components/CuTextField'
 import CuTextFieldLabel from '@/components/CuTextFieldLabel'
@@ -10,14 +8,12 @@ import { ISignUpInputs } from '@/types/ISignUpInputs'
 const EmailField = ({
   field,
   emailSendStatus,
-  setEmailSendStatus,
   submitEmail,
   isSubmitting,
   error,
 }: {
   field: ControllerRenderProps<ISignUpInputs, 'email'>
   emailSendStatus: 'before' | 'submit' | 'error'
-  setEmailSendStatus: Dispatch<SetStateAction<'before' | 'submit' | 'error'>>
   submitEmail: () => void
   isSubmitting: boolean
   error: FieldError | undefined
@@ -26,13 +22,8 @@ const EmailField = ({
     <>
       <CuTextFieldLabel htmlFor="email">이메일</CuTextFieldLabel>
       <CuTextField
-        field={{
-          ...field,
-          onChange: (e: any) => {
-            field.onChange(e)
-            setEmailSendStatus('before')
-          },
-        }}
+        field={field}
+        disabled={emailSendStatus === 'submit'}
         autoComplete="off"
         error={emailSendStatus === 'error'}
         type="text"
@@ -45,7 +36,7 @@ const EmailField = ({
             <InputAdornment position="end">
               <Button
                 variant="contained"
-                disabled={isSubmitting}
+                disabled={isSubmitting || emailSendStatus === 'submit'}
                 onClick={submitEmail}
               >
                 이메일 인증


### PR DESCRIPTION
### 구현사항
- 닉네임 필드 validation 추가했습니다.
- 닉네임 한글, 영문, 숫자만 사용가능하게 했습니다.
- 이메일 필드, 전송코드 필드가 제출되고 나서는 입력을 수정하지 못하게 막았습니다.
- toast UI 적용시켰습니다.