### PR TITLE
[B-INFO] 회원가입 인증코드 에러 수정

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -196,12 +196,14 @@ const SignUp = () => {
     } else {
       const { email, password, name, nickName } = data
       try {
+        const social = socialEmail ? socialEmail : null
+        console.log(email, password, name, nickName, social)
         await axios.post(`${API_URL}/api/v1/signup/form`, {
           email: email,
           password: password,
           name: name,
           nickName: nickName,
-          socialEmail: socialEmail ? socialEmail : null,
+          socialEmail: social,
         })
         setToastMessage('회원가입이 완료되었습니다')
         router.push('/') // 메인페이지로 이동

--- a/src/app/signup/panel/CodeField.tsx
+++ b/src/app/signup/panel/CodeField.tsx
@@ -26,7 +26,7 @@ const CodeField = ({
         type="text"
         placeholder="인증번호를 입력하세요"
         inputProps={{
-          maxLength: 6,
+          maxLength: 10,
         }}
         InputProps={{
           endAdornment: (


### PR DESCRIPTION
- 텍스트 필드 최대 입력값을 10으로 바꿔서 인증코드 에러 문제를 해결했습니다.
- 회원가입 폼 제출할 때 유효하지 않다고 나오는데 이거는 해결을 못했습니다. 일단 콘솔로 찍어봤을 때 문제가 없어 보입니다.