### PR TITLE
[A-JOI] 개인정보동의서명 와이어프레임반영 및 체크박스로직, route 추가

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,19 +1,59 @@
 'use client'
 
 import CuButton from '@/components/CuButton'
-import { Checkbox, FormControlLabel, Paper, Typography } from '@mui/material'
+import useMedia from '@/hook/useMedia'
+import {
+  Checkbox,
+  Container,
+  FormControlLabel,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
+const PCLoginBox = {
+  display: 'flex',
+  position: 'relative',
+  width: '496px',
+  padding: '24px 24px 40px 24px',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '48px',
+  borderRadius: '16px',
+  border: '1px solid #000',
+}
+
+const MobileLoginBox = {
+  display: 'flex',
+  width: '100%',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '0 32px 15px 32px',
+}
+
+const PCPaper = {
+  width: '450px',
+  height: '100px',
+  overflow: 'auto',
+}
+
+const MobilePaper = {
+  width: '100%',
+  height: '100px',
+  overflow: 'auto',
+}
+
+const Policy1 =
+  '이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다. 이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다. 이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다. 이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다. 이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다. 이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다.이 부분은 테스트 약관입니다. 자세한 내용은 추후에 업데이트 될 예정입니다.'
+
 const Privacy = () => {
+  const { isPc } = useMedia()
   const [checkAll, setCheckAll] = useState<boolean>(false)
   const [checkStatus, setCheckStatus] = useState<boolean[]>([false, false])
   const [disabled, setDisabled] = useState<boolean>(true)
   const router = useRouter()
-
-  useEffect(() => {
-    console.log(checkStatus)
-  }, [checkStatus])
 
   useEffect(() => {
     if (!checkStatus[0] || !checkStatus[1]) {
@@ -30,47 +70,52 @@ const Privacy = () => {
 
   return (
     <>
-      <Typography variant="h4">개인정보처리방침</Typography>
-      <FormControlLabel
-        control={<Checkbox />}
-        label="전체 동의하기"
-        onChange={() => {
-          if (checkAll === false) setCheckStatus([true, true])
-          setCheckAll(!checkAll)
-        }}
-        checked={checkAll}
-      />
-      <Typography>
-        실명 인증된 아이디로 가입,이벤트 혜택 정보 수신(선택) 동의를 포함합니다.
-      </Typography>
-      <FormControlLabel
-        control={<Checkbox />}
-        onChange={() => {
-          setCheckStatus([!checkStatus[0], checkStatus[1]])
-        }}
-        label="[필수] peer 이용 약관"
-        checked={checkStatus[0]}
-      />
-      <Paper sx={{ width: '450px', height: '100px' }}>
-        이부분은 테스트 약관입니다.
-      </Paper>
-      <FormControlLabel
-        control={<Checkbox />}
-        label="[필수] 개인정보 수집 및 이용"
-        onChange={() => {
-          setCheckStatus([checkStatus[0], !checkStatus[1]])
-        }}
-        checked={checkStatus[1]}
-      />
-      <Paper sx={{ width: '450px', height: '100px' }}>
-        이부분은 테스트 약관입니다.
-      </Paper>
-      <CuButton
-        message={'다음'}
-        action={onClick}
-        variant={'contained'}
-        disabled={disabled}
-      />
+      <Container sx={isPc ? PCLoginBox : MobileLoginBox}>
+        <Typography variant="h4">개인정보처리방침</Typography>
+        <Stack>
+          <FormControlLabel
+            control={<Checkbox />}
+            label="전체 동의하기"
+            onChange={() => {
+              if (checkAll === false) setCheckStatus([true, true])
+              setCheckAll(!checkAll)
+            }}
+            checked={checkAll}
+          />
+          <Typography>
+            실명 인증된 아이디로 가입,이벤트 혜택 정보 수신(선택) 동의를
+            포함합니다.
+          </Typography>
+        </Stack>
+        <Stack>
+          <Paper sx={isPc ? PCPaper : MobilePaper}> {Policy1}</Paper>
+          <FormControlLabel
+            control={<Checkbox />}
+            onChange={() => {
+              setCheckStatus([!checkStatus[0], checkStatus[1]])
+            }}
+            label="[필수] peer 이용 약관"
+            checked={checkStatus[0]}
+          />
+        </Stack>
+        <Stack>
+          <Paper sx={isPc ? PCPaper : MobilePaper}>{Policy1}</Paper>
+          <FormControlLabel
+            control={<Checkbox />}
+            label="[필수] 개인정보 수집 및 이용"
+            onChange={() => {
+              setCheckStatus([checkStatus[0], !checkStatus[1]])
+            }}
+            checked={checkStatus[1]}
+          />
+        </Stack>
+        <CuButton
+          message={'다음'}
+          action={onClick}
+          variant={'contained'}
+          disabled={disabled}
+        />
+      </Container>
     </>
   )
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,23 +1,76 @@
+'use client'
+
+import CuButton from '@/components/CuButton'
 import { Checkbox, FormControlLabel, Paper, Typography } from '@mui/material'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 const Privacy = () => {
+  const [checkAll, setCheckAll] = useState<boolean>(false)
+  const [checkStatus, setCheckStatus] = useState<boolean[]>([false, false])
+  const [disabled, setDisabled] = useState<boolean>(true)
+  const router = useRouter()
+
+  useEffect(() => {
+    console.log(checkStatus)
+  }, [checkStatus])
+
+  useEffect(() => {
+    if (!checkStatus[0] || !checkStatus[1]) {
+      setCheckAll(false)
+    }
+    if (checkStatus[0] && checkStatus[1]) {
+      setDisabled(false)
+    } else setDisabled(true)
+  }, [checkStatus])
+
+  const onClick = () => {
+    if (checkStatus[0] && checkStatus[1]) router.push('/signup')
+  }
+
   return (
     <>
       <Typography variant="h4">개인정보처리방침</Typography>
       <FormControlLabel
-        control={<Checkbox defaultChecked />}
+        control={<Checkbox />}
         label="전체 동의하기"
+        onChange={() => {
+          if (checkAll === false) setCheckStatus([true, true])
+          setCheckAll(!checkAll)
+        }}
+        checked={checkAll}
       />
       <Typography>
         실명 인증된 아이디로 가입,이벤트 혜택 정보 수신(선택) 동의를 포함합니다.
       </Typography>
-      <FormControlLabel control={<Checkbox />} label="[필수] peer 이용 약관" />
-      <Paper sx={{ width: '450px', height: '100px' }}>이부분은 테스트 약관입니다.</Paper>
+      <FormControlLabel
+        control={<Checkbox />}
+        onChange={() => {
+          setCheckStatus([!checkStatus[0], checkStatus[1]])
+        }}
+        label="[필수] peer 이용 약관"
+        checked={checkStatus[0]}
+      />
+      <Paper sx={{ width: '450px', height: '100px' }}>
+        이부분은 테스트 약관입니다.
+      </Paper>
       <FormControlLabel
         control={<Checkbox />}
         label="[필수] 개인정보 수집 및 이용"
+        onChange={() => {
+          setCheckStatus([checkStatus[0], !checkStatus[1]])
+        }}
+        checked={checkStatus[1]}
       />
-      <Paper sx={{ width: '450px', height: '100px' }}>이부분은 테스트 약관입니다.</Paper>
+      <Paper sx={{ width: '450px', height: '100px' }}>
+        이부분은 테스트 약관입니다.
+      </Paper>
+      <CuButton
+        message={'다음'}
+        action={onClick}
+        variant={'contained'}
+        disabled={disabled}
+      />
     </>
   )
 }


### PR DESCRIPTION
### 변경된점
- 와이어프레임 디자인 반영 (회원가입 디자인과 동일)
- 체크박스 로직 반영
- 다음을 누르면 signup 페이지로 리디렉션

### 필요한 작업
- login 페이지에서 회원가입 버튼 누를시 privcay 페이지로 리디렉션작업이 필요함 지금은 privacy를 거치지 않고 회원가입페이지로 넘어감.
@KRimwoo 
