### PR TITLE
[C-MYPAGE-11] 개인정보 페이지에서 비밀번호 변경 API 수정

### DIFF
--- a/src/app/my-page/privacy/panel/EyeIcon.tsx
+++ b/src/app/my-page/privacy/panel/EyeIcon.tsx
@@ -1,0 +1,26 @@
+import { Dispatch, SetStateAction } from 'react'
+import IconButton from '@mui/material/IconButton'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+
+const EyeIcon = ({
+  showPassword,
+  setShowPassword,
+}: {
+  showPassword: 'password' | 'text'
+  setShowPassword: Dispatch<SetStateAction<'password' | 'text'>>
+}) => {
+  return (
+    <>
+      <IconButton
+        onClick={() => {
+          setShowPassword(showPassword === 'password' ? 'text' : 'password')
+        }}
+      >
+        {showPassword ? <VisibilityIcon /> : <VisibilityOffIcon />}
+      </IconButton>
+    </>
+  )
+}
+
+export default EyeIcon

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -1,11 +1,15 @@
 'use client'
 
-import { Dispatch, SetStateAction } from 'react'
+import { useState, Dispatch, SetStateAction } from 'react'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import { Button, Typography, Container, Stack } from '@mui/material'
 import CuTextField from '@/components/CuTextField'
 import useAxiosWithAuth from '@/api/config'
 import IToastProps from '@/types/IToastProps'
+
+import IconButton from '@mui/material/IconButton'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 
 interface IChangePassword {
   presentPassword: string
@@ -30,10 +34,20 @@ export default function UserInfoEdit({
     formState: { errors },
     getValues,
   } = useForm<IChangePassword>({ mode: 'onChange' })
+  const [showPresentPassword, setShowPresentPassword] = useState<
+    'password' | 'text'
+  >('password')
+  const [showNewPassword, setShowNewPassword] = useState<'password' | 'text'>(
+    'password',
+  )
+  const [showConfirmPassword, setShowConfirmPassword] = useState<
+    'password' | 'text'
+  >('password')
 
   const axiosWithAuth = useAxiosWithAuth()
   const changePassword: SubmitHandler<IChangePassword> = async (data) => {
     try {
+      console.log(data)
       await axiosWithAuth.put(`/api/v1/info/password`, data)
       setToastProps({
         severity: 'success',
@@ -87,10 +101,29 @@ export default function UserInfoEdit({
               render={({ field }) => (
                 <CuTextField
                   field={field}
-                  type="password"
+                  type={showPresentPassword}
                   autoComplete="off"
                   error={errors.presentPassword ? true : false}
                   placeholder="현재 비밀번호"
+                  InputProps={{
+                    endAdornment: (
+                      <IconButton
+                        onClick={() => {
+                          setShowPresentPassword(
+                            showPresentPassword === 'password'
+                              ? 'text'
+                              : 'password',
+                          )
+                        }}
+                      >
+                        {showPresentPassword === 'password' ? (
+                          <VisibilityIcon />
+                        ) : (
+                          <VisibilityOffIcon />
+                        )}
+                      </IconButton>
+                    ),
+                  }}
                 />
               )}
             />
@@ -109,10 +142,29 @@ export default function UserInfoEdit({
               render={({ field }) => (
                 <CuTextField
                   field={field}
-                  type="password"
+                  type={showNewPassword}
                   autoComplete="off"
                   error={errors.newPassword ? true : false}
                   placeholder="새로운 비밀번호"
+                  InputProps={{
+                    endAdornment: (
+                      <IconButton
+                        onClick={() => {
+                          setShowNewPassword(
+                            showNewPassword === 'password'
+                              ? 'text'
+                              : 'password',
+                          )
+                        }}
+                      >
+                        {showNewPassword === 'password' ? (
+                          <VisibilityIcon />
+                        ) : (
+                          <VisibilityOffIcon />
+                        )}
+                      </IconButton>
+                    ),
+                  }}
                 />
               )}
             />
@@ -134,10 +186,29 @@ export default function UserInfoEdit({
               render={({ field }) => (
                 <CuTextField
                   field={field}
-                  type="password"
+                  type={showConfirmPassword}
                   autoComplete="off"
                   error={errors.confirmPassword ? true : false}
                   placeholder="새로운 비밀번호 재입력"
+                  InputProps={{
+                    endAdornment: (
+                      <IconButton
+                        onClick={() => {
+                          setShowConfirmPassword(
+                            showConfirmPassword === 'password'
+                              ? 'text'
+                              : 'password',
+                          )
+                        }}
+                      >
+                        {showConfirmPassword === 'password' ? (
+                          <VisibilityIcon />
+                        ) : (
+                          <VisibilityOffIcon />
+                        )}
+                      </IconButton>
+                    ),
+                  }}
                 />
               )}
             />

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -43,7 +43,17 @@ export default function UserInfoEdit({
       if (error.response?.status === 404) {
         setToastProps({
           severity: 'error',
-          message: error.response.data.message,
+          message: error.response.data.message, // 사용자를 찾을 수 없음. 토큰 문제
+        })
+      } else if (error.response?.status === 400) {
+        setToastProps({
+          severity: 'error',
+          message: error.response.data.message, // 변경할 비밀번호가 일치하지 않음
+        })
+      } else if (error.response?.status === 401) {
+        setToastProps({
+          severity: 'error',
+          message: error.response.data.message, // 현재 비밀번호가 올바르지 않음
         })
       }
       console.log(error)

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -7,9 +7,7 @@ import CuTextField from '@/components/CuTextField'
 import useAxiosWithAuth from '@/api/config'
 import IToastProps from '@/types/IToastProps'
 
-import IconButton from '@mui/material/IconButton'
-import VisibilityIcon from '@mui/icons-material/Visibility'
-import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+import EyeIcon from './EyeIcon'
 
 interface IChangePassword {
   presentPassword: string
@@ -120,21 +118,10 @@ export default function UserInfoEdit({
                   placeholder="현재 비밀번호"
                   InputProps={{
                     endAdornment: (
-                      <IconButton
-                        onClick={() => {
-                          setShowPresentPassword(
-                            showPresentPassword === 'password'
-                              ? 'text'
-                              : 'password',
-                          )
-                        }}
-                      >
-                        {showPresentPassword === 'password' ? (
-                          <VisibilityIcon />
-                        ) : (
-                          <VisibilityOffIcon />
-                        )}
-                      </IconButton>
+                      <EyeIcon
+                        showPassword={showPresentPassword}
+                        setShowPassword={setShowPresentPassword}
+                      />
                     ),
                   }}
                 />
@@ -161,21 +148,10 @@ export default function UserInfoEdit({
                   placeholder="새로운 비밀번호"
                   InputProps={{
                     endAdornment: (
-                      <IconButton
-                        onClick={() => {
-                          setShowNewPassword(
-                            showNewPassword === 'password'
-                              ? 'text'
-                              : 'password',
-                          )
-                        }}
-                      >
-                        {showNewPassword === 'password' ? (
-                          <VisibilityIcon />
-                        ) : (
-                          <VisibilityOffIcon />
-                        )}
-                      </IconButton>
+                      <EyeIcon
+                        showPassword={showNewPassword}
+                        setShowPassword={setShowNewPassword}
+                      />
                     ),
                   }}
                 />
@@ -200,21 +176,10 @@ export default function UserInfoEdit({
                   placeholder="새로운 비밀번호 재입력"
                   InputProps={{
                     endAdornment: (
-                      <IconButton
-                        onClick={() => {
-                          setShowConfirmPassword(
-                            showConfirmPassword === 'password'
-                              ? 'text'
-                              : 'password',
-                          )
-                        }}
-                      >
-                        {showConfirmPassword === 'password' ? (
-                          <VisibilityIcon />
-                        ) : (
-                          <VisibilityOffIcon />
-                        )}
-                      </IconButton>
+                      <EyeIcon
+                        showPassword={showConfirmPassword}
+                        setShowPassword={setShowConfirmPassword}
+                      />
                     ),
                   }}
                 />

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -60,20 +60,14 @@ export default function UserInfoEdit({
       })
       reset()
     } catch (error: any) {
-      if (error.response?.status === 404) {
+      if (
+        error.response?.status === 404 || // 사용자를 찾을 수 없음
+        error.response?.status === 400 || // 변경할 비밀번호와 확인 비밀번호가 일치하지 않음
+        error.response?.status === 403 // 현재 비밀번호가 올바르지 않음
+      ) {
         setToastProps({
           severity: 'error',
-          message: error.response.data.message, // 사용자를 찾을 수 없음. 토큰 문제
-        })
-      } else if (error.response?.status === 400) {
-        setToastProps({
-          severity: 'error',
-          message: error.response.data.message, // 변경할 비밀번호가 일치하지 않음
-        })
-      } else if (error.response?.status === 403) {
-        setToastProps({
-          severity: 'error',
-          message: error.response.data.message, // 현재 비밀번호가 올바르지 않음
+          message: error.response.data.message,
         })
       } else {
         setToastProps({

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -33,7 +33,15 @@ export default function UserInfoEdit({
     control,
     formState: { errors },
     getValues,
-  } = useForm<IChangePassword>({ mode: 'onChange' })
+    reset,
+  } = useForm<IChangePassword>({
+    defaultValues: {
+      presentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  })
   const [showPresentPassword, setShowPresentPassword] = useState<
     'password' | 'text'
   >('password')
@@ -52,6 +60,7 @@ export default function UserInfoEdit({
         severity: 'success',
         message: '비밀번호가 변경되었습니다',
       })
+      reset()
     } catch (error: any) {
       if (error.response?.status === 404) {
         setToastProps({
@@ -178,11 +187,6 @@ export default function UserInfoEdit({
               defaultValue=""
               rules={{
                 required: true,
-                pattern: {
-                  value:
-                    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[~!@#$%^&*<>])[A-Za-z\d~!@#$%^&*<>]{8,}$/i,
-                  message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
-                },
                 validate: (value) =>
                   value === getValues('newPassword') ||
                   '비밀번호가 일치하지 않습니다',

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -139,7 +139,7 @@ export default function UserInfoEdit({
                 required: true,
                 pattern: {
                   value:
-                    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[~!@#$%^&*<>])[A-Za-z\d~!@#$%^&*<>]{8,}$/i,
+                    /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/i,
                   message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
                 },
               }}

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -2,7 +2,7 @@
 
 import { Dispatch, SetStateAction } from 'react'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
-import { Button, Typography, Container } from '@mui/material'
+import { Button, Typography, Container, Stack } from '@mui/material'
 import CuTextField from '@/components/CuTextField'
 import useAxiosWithAuth from '@/api/config'
 import IToastProps from '@/types/IToastProps'
@@ -77,82 +77,84 @@ export default function UserInfoEdit({
         {authentication ? <Typography>{authentication}</Typography> : null}
         <Button>인증하기</Button>
         <form onSubmit={handleSubmit(changePassword)}>
-          <Typography>비밀번호</Typography>
-          <Controller
-            name="presentPassword"
-            control={control}
-            defaultValue=""
-            rules={{ required: true }}
-            render={({ field }) => (
-              <CuTextField
-                field={field}
-                type="password"
-                autoComplete="off"
-                error={errors.presentPassword ? true : false}
-                placeholder="현재 비밀번호"
-              />
+          <Stack spacing={1}>
+            <Typography>비밀번호</Typography>
+            <Controller
+              name="presentPassword"
+              control={control}
+              defaultValue=""
+              rules={{ required: true }}
+              render={({ field }) => (
+                <CuTextField
+                  field={field}
+                  type="password"
+                  autoComplete="off"
+                  error={errors.presentPassword ? true : false}
+                  placeholder="현재 비밀번호"
+                />
+              )}
+            />
+            <Controller
+              name="newPassword"
+              control={control}
+              defaultValue=""
+              rules={{
+                required: true,
+                pattern: {
+                  value:
+                    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[~!@#$%^&*<>])[A-Za-z\d~!@#$%^&*<>]{8,}$/i,
+                  message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
+                },
+              }}
+              render={({ field }) => (
+                <CuTextField
+                  field={field}
+                  type="password"
+                  autoComplete="off"
+                  error={errors.newPassword ? true : false}
+                  placeholder="새로운 비밀번호"
+                />
+              )}
+            />
+            <Controller
+              name="confirmPassword"
+              control={control}
+              defaultValue=""
+              rules={{
+                required: true,
+                pattern: {
+                  value:
+                    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[~!@#$%^&*<>])[A-Za-z\d~!@#$%^&*<>]{8,}$/i,
+                  message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
+                },
+                validate: (value) =>
+                  value !== getValues('newPassword') &&
+                  '비밀번호가 일치하지 않습니다',
+              }}
+              render={({ field }) => (
+                <CuTextField
+                  field={field}
+                  type="password"
+                  autoComplete="off"
+                  error={errors.confirmPassword ? true : false}
+                  placeholder="새로운 비밀번호 재입력"
+                />
+              )}
+            />
+            {errors.newPassword ? (
+              <Typography color="error">
+                {errors.newPassword.message
+                  ? errors.newPassword.message
+                  : '비밀번호를 입력해주세요'}
+              </Typography>
+            ) : errors.confirmPassword ? (
+              <Typography color="error">
+                {errors.confirmPassword.message}
+              </Typography>
+            ) : (
+              <Typography>&nbsp;</Typography>
             )}
-          />
-          <Controller
-            name="newPassword"
-            control={control}
-            defaultValue=""
-            rules={{
-              required: true,
-              pattern: {
-                value:
-                  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[~!@#$%^&*<>])[A-Za-z\d~!@#$%^&*<>]{8,}$/i,
-                message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
-              },
-            }}
-            render={({ field }) => (
-              <CuTextField
-                field={field}
-                type="password"
-                autoComplete="off"
-                error={errors.newPassword ? true : false}
-                placeholder="새로운 비밀번호"
-              />
-            )}
-          />
-          <Controller
-            name="confirmPassword"
-            control={control}
-            defaultValue=""
-            rules={{
-              required: true,
-              pattern: {
-                value:
-                  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[~!@#$%^&*<>])[A-Za-z\d~!@#$%^&*<>]{8,}$/i,
-                message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
-              },
-              validate: (value) =>
-                value !== getValues('newPassword') &&
-                '비밀번호가 일치하지 않습니다',
-            }}
-            render={({ field }) => (
-              <CuTextField
-                field={field}
-                type="password"
-                autoComplete="off"
-                error={errors.confirmPassword ? true : false}
-                placeholder="새로운 비밀번호 재입력"
-              />
-            )}
-          />
-          {errors.newPassword ? (
-            <Typography color="error">
-              {errors.newPassword.message
-                ? errors.newPassword.message
-                : '비밀번호를 입력해주세요'}
-            </Typography>
-          ) : errors.confirmPassword ? (
-            <Typography color="error">
-              {errors.confirmPassword.message}
-            </Typography>
-          ) : (
-            <Typography>&nbsp;</Typography>
-          )}
+          </Stack>
           <Button type="submit">변경하기</Button>
         </form>
       </Container>

--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -47,7 +47,6 @@ export default function UserInfoEdit({
   const axiosWithAuth = useAxiosWithAuth()
   const changePassword: SubmitHandler<IChangePassword> = async (data) => {
     try {
-      console.log(data)
       await axiosWithAuth.put(`/api/v1/info/password`, data)
       setToastProps({
         severity: 'success',
@@ -64,10 +63,15 @@ export default function UserInfoEdit({
           severity: 'error',
           message: error.response.data.message, // 변경할 비밀번호가 일치하지 않음
         })
-      } else if (error.response?.status === 401) {
+      } else if (error.response?.status === 403) {
         setToastProps({
           severity: 'error',
           message: error.response.data.message, // 현재 비밀번호가 올바르지 않음
+        })
+      } else {
+        setToastProps({
+          severity: 'error',
+          message: '비밀번호 변경에 실패했습니다',
         })
       }
       console.log(error)
@@ -180,7 +184,7 @@ export default function UserInfoEdit({
                   message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
                 },
                 validate: (value) =>
-                  value !== getValues('newPassword') &&
+                  value === getValues('newPassword') ||
                   '비밀번호가 일치하지 않습니다',
               }}
               render={({ field }) => (


### PR DESCRIPTION
- 비밀번호 변경 API에 맞게 수정했습니다.
- 패스워드를 볼 수 있게 눈모양 아이콘을 넣었습니다.
- 패스워드 검증 로직을 회원가입하고 맞췄습니다.
- 비밀번호를 바꾸고 난 후 필드를 리셋시켰습니다. 
<img width="688" alt="스크린샷 2023-11-08 오후 4 36 35" src="https://github.com/peer-42seoul/Peer-Frontend/assets/114281631/cbdc7623-d293-455b-9f0f-7fa96641b5ad">
