### PR TITLE
[C-SIGN] find-account 페이지의 api 연동 오류 수정 + interceptor reissue 오류 수정

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -14,6 +14,9 @@ const useAxiosWithAuth = () => {
     baseURL: process.env.NEXT_PUBLIC_API_URL,
   })
 
+  //무한 요청 방지
+  let isRefreshing = false
+
   axiosInstance.interceptors.request.use(
     (config: InternalAxiosRequestConfig) => {
       if (accessToken) {
@@ -31,16 +34,16 @@ const useAxiosWithAuth = () => {
       return response
     },
     async (error) => {
+      console.log('is refreshing?', isRefreshing)
+      isRefreshing = true
       const currentPageUrl = window.location.pathname
-      console.log(currentPageUrl)
       if (error.response?.status === 401) {
-        console.log('successful error handling')
-        if (!refreshToken || !accessToken) {
+        if (!refreshToken || !accessToken || isRefreshing) {
           // 로그아웃 후 리디렉션
+
           useAuthStore.getState().logout()
           removeCookie('refreshToken', { path: '/' })
           router.push('/login?redirect=' + currentPageUrl)
-          return
         } else {
           try {
             // accessToken 갱신 요청
@@ -50,17 +53,16 @@ const useAxiosWithAuth = () => {
                 refreshToken: refreshToken,
               },
             )
-
             const newAccessToken = response.data.accessToken
             useAuthStore.getState().login(newAccessToken)
-
+            error.config.headers['Authorization'] = `Bearer ${newAccessToken}`
             // 이전 요청을 재시도
-            return axiosInstance(error.config)
+            return axios.request(error.config)
+            //return axiosInstance(error.config)
           } catch (refreshError) {
             // 로그아웃 후 리디렉션
             useAuthStore.getState().logout()
             removeCookie('refreshToken', { path: '/' })
-            alert('다시 로그인 해주세요')
             router.push('/login?redirect=' + currentPageUrl)
           }
         }

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -62,7 +62,6 @@ const useAxiosWithAuth = () => {
             removeCookie('refreshToken', { path: '/' })
             alert('다시 로그인 해주세요')
             router.push('/login?redirect=' + currentPageUrl)
-            return
           }
         }
       }

--- a/src/app/find-account/panel/SendCodeForm.tsx
+++ b/src/app/find-account/panel/SendCodeForm.tsx
@@ -77,12 +77,12 @@ const SendCodeForm = ({
 
   const onSubmit = async (data: { code: string }) => {
     const code = data.code
-    const codeData = JSON.stringify({ email, code })
     //console.log(codeData)
 
     axios
-      .post(`${API_URL}/api/v1/signin/find_password`, {
-        codeData,
+      .post(`${API_URL}/api/v1/signin/find-password`, {
+        email: email,
+        code: code,
       })
       .then((res) => {
         if (res.status == 200) {

--- a/src/app/find-account/panel/SendEmailForm.tsx
+++ b/src/app/find-account/panel/SendEmailForm.tsx
@@ -39,11 +39,8 @@ const SendEmailForm = () => {
   } = useForm<{ email: string }>()
 
   const onSubmit = async (data: { email: string }) => {
-    const email = data.email
     axios
-      .post(`${API_URL}/api/v1/signin/find`, {
-        email: email,
-      })
+      .post(`${API_URL}/api/v1/signin/find`, data)
       .then((res) => {
         if (res.status == 200) setIsEmailSuccessful(true)
       })

--- a/src/app/find-account/panel/SendEmailForm.tsx
+++ b/src/app/find-account/panel/SendEmailForm.tsx
@@ -39,9 +39,10 @@ const SendEmailForm = () => {
   } = useForm<{ email: string }>()
 
   const onSubmit = async (data: { email: string }) => {
+    const email = data.email
     axios
       .post(`${API_URL}/api/v1/signin/find`, {
-        data,
+        email: email,
       })
       .then((res) => {
         if (res.status == 200) setIsEmailSuccessful(true)
@@ -49,6 +50,8 @@ const SendEmailForm = () => {
       .catch((error) => {
         if (error.response.status == 404)
           setErrorMessage('존재하지 않는 회원입니다.')
+        else if (error.response.status == 401)
+          setErrorMessage('이메일 전송에 실패했습니다. 다시 시도해주세요.')
         else setErrorMessage('알 수 없는 오류가 발생했습니다.')
         openToast()
       })


### PR DESCRIPTION
## 작업 내용
- 백에서 요구하는 데이터 형식과 주소에 맞추어 코드를 다시 수정하고 연동이 잘 되는지 테스트까지 해보았습니다.

## 참고
- 다만, 이메일로 받는 임시비밀번호 자체에는 아직 문제가 있는 상황이라 임시비밀번호로 로그인까지는 불가능한 상황입니다