### PR TITLE
[C-MAIN][J-TB] 메인페이지, 모집글 뷰페이지의 API 연동에 따른 변수수정 + 세부옵션 수정

### DIFF
--- a/src/app/my-page/interests/page.tsx
+++ b/src/app/my-page/interests/page.tsx
@@ -33,8 +33,8 @@ interface IMainCard {
   user_thumbnail: string
   status: string
   tagList: ITag[]
-  isFavorite: boolean
-  post_id: number
+  favorite: boolean
+  recruit_id: number
   type: ProjectType
 }
 
@@ -230,7 +230,7 @@ const MyInterests = () => {
         direction="row"
       >
         {postList.map((item) => (
-          <Grid item key={item.post_id} xs={10} sm={4}>
+          <Grid item key={item.recruit_id} xs={10} sm={4}>
             <MainCard {...item} type={type as ProjectType} />
           </Grid>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import MainPage from './panel/MainPage'
 
 export default async function Home() {
   const data = await fetchServerData(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=STUDY&sort=latest&page=1&pageSize=10&keyword=&due=&region1=&region2=&place=&status=&tag=`
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=STUDY&sort=latest&page=1&pageSize=10&keyword=&due=&region1=&region2=&place=&status=&tag=`,
   )
   return <MainPage initData={data?.content} />
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import MainPage from './panel/MainPage'
 
 export default async function Home() {
   const data = await fetchServerData(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=STUDY&sort=latest&page=1&pageSize=10&keyword=&due=&region=&place=&status=&tag=`
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=STUDY&sort=latest&page=1&pageSize=10&keyword=&due=&region1=&region2=&place=&status=&tag=`
   )
   return <MainPage initData={data?.content} />
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import MainPage from './panel/MainPage'
 
 export default async function Home() {
   const data = await fetchServerData(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=studies&sort=latest&page=1&pageSize=10&keyword=&due=&region=&place=&status=&tag=`
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=STUDY&sort=latest&page=1&pageSize=10&keyword=&due=&region=&place=&status=&tag=`
   )
   return <MainPage initData={data?.content} />
 }

--- a/src/app/panel/MainCard.tsx
+++ b/src/app/panel/MainCard.tsx
@@ -63,7 +63,10 @@ const MainCard = ({
 
   return (
     <Card sx={{ maxWidth: 345 }}>
-      <Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }} >
+      <Link
+        href={`/recruitment/${recruit_id}?type=${type}`}
+        style={{ textDecoration: 'none' }}
+      >
         <Box sx={{ position: 'relative' }}>
           <CardMedia
             component="img"
@@ -87,7 +90,10 @@ const MainCard = ({
       </Link>
       <CardHeader
         avatar={
-          <Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }}>
+          <Link
+            href={`/recruitment/${recruit_id}?type=${type}`}
+            style={{ textDecoration: 'none' }}
+          >
             <Avatar sx={{ bgcolor: red[500] }} aria-label="profile">
               <Box
                 component="img"
@@ -103,9 +109,19 @@ const MainCard = ({
             <Favorite sx={{ color: isFavorite ? 'red' : 'gray' }} />
           </IconButton>
         }
-        title={<Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }}>{user_nickname}</Link>}
+        title={
+          <Link
+            href={`/recruitment/${recruit_id}?type=${type}`}
+            style={{ textDecoration: 'none' }}
+          >
+            {user_nickname}
+          </Link>
+        }
       />
-      <Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }}>
+      <Link
+        href={`/recruitment/${recruit_id}?type=${type}`}
+        style={{ textDecoration: 'none' }}
+      >
         <CardContent>
           <Typography variant="body2" color="text.secondary">
             {title}

--- a/src/app/panel/MainCard.tsx
+++ b/src/app/panel/MainCard.tsx
@@ -4,7 +4,6 @@ import {
   Avatar,
   Box,
   Card,
-  CardActions,
   CardContent,
   CardHeader,
   CardMedia,
@@ -13,8 +12,7 @@ import {
   Typography,
 } from '@mui/material'
 import { red } from '@mui/material/colors'
-import { use, useState } from 'react'
-import axios from 'axios'
+import { useState } from 'react'
 import useAuthStore from '@/states/useAuthStore'
 import { useRouter } from 'next/navigation'
 import { ProjectType } from './MainPage'

--- a/src/app/panel/MainCard.tsx
+++ b/src/app/panel/MainCard.tsx
@@ -4,20 +4,22 @@ import {
   Avatar,
   Box,
   Card,
+  CardActions,
   CardContent,
   CardHeader,
   CardMedia,
   Chip,
   IconButton,
-  Link,
   Typography,
 } from '@mui/material'
 import { red } from '@mui/material/colors'
-import { useState } from 'react'
+import { use, useState } from 'react'
 import axios from 'axios'
 import useAuthStore from '@/states/useAuthStore'
 import { useRouter } from 'next/navigation'
 import { ProjectType } from './MainPage'
+import useAxiosWithAuth from '@/api/config'
+import Link from 'next/link'
 
 interface IMainCard {
   title: string
@@ -27,8 +29,8 @@ interface IMainCard {
   user_thumbnail: string
   status: string
   tagList: ITag[]
-  isFavorite?: boolean
-  post_id: number
+  favorite?: boolean
+  recruit_id: number
   type: ProjectType
 }
 const MainCard = ({
@@ -38,32 +40,30 @@ const MainCard = ({
   user_thumbnail,
   status,
   tagList,
-  isFavorite,
-  post_id,
+  favorite,
+  recruit_id,
   type,
 }: IMainCard) => {
-  const [favorite, setFavorite] = useState(isFavorite)
+  const [isFavorite, setIsFavorite] = useState(favorite)
   const { isLogin } = useAuthStore()
   const router = useRouter()
 
+  const axiosInstance = useAxiosWithAuth()
   const changeFavorite = async () => {
     if (!isLogin) return router.push('/login')
     try {
-      await axios(
-        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/favorite/${post_id}`,
+      await axiosInstance.post(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/favorite/${recruit_id}`,
       )
-      setFavorite(!favorite)
+      setIsFavorite(!isFavorite)
     } catch (e) {
       console.log('error', e)
     }
   }
 
   return (
-    <Link
-      href={`/recruitment/${post_id}?type=${type}`}
-      style={{ textDecoration: 'none' }}
-    >
-      <Card sx={{ maxWidth: 345 }}>
+    <Card sx={{ maxWidth: 345 }}>
+      <Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }} >
         <Box sx={{ position: 'relative' }}>
           <CardMedia
             component="img"
@@ -84,8 +84,10 @@ const MainCard = ({
             size="medium"
           />
         </Box>
-        <CardHeader
-          avatar={
+      </Link>
+      <CardHeader
+        avatar={
+          <Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }}>
             <Avatar sx={{ bgcolor: red[500] }} aria-label="profile">
               <Box
                 component="img"
@@ -94,14 +96,16 @@ const MainCard = ({
                 alt="profile image"
               />
             </Avatar>
-          }
-          action={
-            <IconButton aria-label="add to favorites" onClick={changeFavorite}>
-              <Favorite sx={{ color: favorite ? 'red' : 'gray' }} />
-            </IconButton>
-          }
-          title={user_nickname}
-        />
+          </Link>
+        }
+        action={
+          <IconButton aria-label="add to favorites" onClick={changeFavorite}>
+            <Favorite sx={{ color: isFavorite ? 'red' : 'gray' }} />
+          </IconButton>
+        }
+        title={<Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }}>{user_nickname}</Link>}
+      />
+      <Link href={`/recruitment/${recruit_id}?type=${type}`} style={{ textDecoration: "none" }}>
         <CardContent>
           <Typography variant="body2" color="text.secondary">
             {title}
@@ -117,8 +121,8 @@ const MainCard = ({
             ))}
           </Box>
         </CardContent>
-      </Card>
-    </Link>
+      </Link>
+    </Card>
   )
 }
 

--- a/src/app/panel/MainPage.tsx
+++ b/src/app/panel/MainPage.tsx
@@ -37,26 +37,25 @@ const MainPage = ({ initData }: { initData: IPagination<IPost[]> }) => {
   /* 추후 디자인 추가되면 schedule 추가하기 */
   const [detailOption, setDetailOption] = useState<{
     due: string
-    region: string
+    region1: string
+    region2: string
     place: string
     status: string
     tag: string
-  }>({ due: '', region: '', place: '', status: '', tag: '' })
+  }>({ due: '', region1: '', region2: '', place: '', status: '', tag: '' })
   const searchParams = useSearchParams()
   const keyword = searchParams.get('keyword') ?? ''
   const { isLogin } = useAuthStore()
   const axiosInstance: AxiosInstance = useAxiosWithAuth()
 
   // useswr의 초기값을 initdata로 설정하려했으나 실패. 지금 코드는 초기에 서버와 클라이언트 둘다 리퀘스트를 보내게 됨
-  const pageSize = 10
+  const pageSize = 5
 
-  const { data, isValidating, error, mutate } = useSWR<IPagination<IPost[]>>(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=${type}&sort=${sort}&page=${page}&pageSize=${pageSize}&keyword=${keyword}&due=${detailOption.due}&region=${detailOption.place}&place=${detailOption.place}&status=${detailOption.status}&tag=${detailOption.tag}`,
+  const { data, isValidating, error, mutate } = useSWR<IPagination<IPost[]>>(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=${type}&sort=${sort}&page=${page}&pageSize=${pageSize}&keyword=${keyword}&due=${detailOption.due}&region1=${detailOption.region1}&region2=${detailOption.region2}&place=${detailOption.place}&status=${detailOption.status}&tag=${detailOption.tag}`,
     isLogin ? (url: string) => axiosInstance.get(url).then((res) => res.data)
       : defaultGetFetcher, {
     fallbackData: initData,
   })
-
-  console.log("data?.totalPages", data?.totalPages);
   const pageLimit = data?.totalPages ?? 1
   const { target, spinner } = useInfiniteScroll({
     setPage,
@@ -64,7 +63,6 @@ const MainPage = ({ initData }: { initData: IPagination<IPost[]> }) => {
     pageLimit,
     page,
   })
-  console.log("data", data);
 
   return (
     <>

--- a/src/app/panel/MainPage.tsx
+++ b/src/app/panel/MainPage.tsx
@@ -13,7 +13,7 @@ import MainCard from './MainCard'
 import SearchOption from './SearchOption'
 import SelectSort from './SelectSort'
 import SelectType from './SelectType'
-import { defaultGetFetcher  } from '@/api/fetchers'
+import { defaultGetFetcher } from '@/api/fetchers'
 import useSWR from 'swr'
 import MainProfile from './MainProfile'
 import MainShowcase from './MainShowcase'
@@ -24,11 +24,12 @@ import { IPost } from '@/types/IPostDetail'
 import useAuthStore from '@/states/useAuthStore'
 import useAxiosWithAuth from '@/api/config'
 import { AxiosInstance } from 'axios'
+import { IPagination } from '@/types/IPagination'
 //latest, hit
 export type ProjectSort = 'latest' | 'hit'
 export type ProjectType = 'STUDY' | 'PROJECT'
 
-const MainPage = ({ initData }: { initData: IPost[] }) => {
+const MainPage = ({ initData }: { initData: IPagination<IPost[]> }) => {
   const [page, setPage] = useState<number>(1)
   const [type, setType] = useState<ProjectType>('STUDY')
   const [openOption, setOpenOption] = useState<boolean>(false)
@@ -49,18 +50,21 @@ const MainPage = ({ initData }: { initData: IPost[] }) => {
   // useswr의 초기값을 initdata로 설정하려했으나 실패. 지금 코드는 초기에 서버와 클라이언트 둘다 리퀘스트를 보내게 됨
   const pageSize = 10
 
-  const { data, isLoading, error, mutate } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=${type}&sort=${sort}&page=${page}&pageSize=${pageSize}&keyword=${keyword}&due=${detailOption.due}&region=${detailOption.place}&place=${detailOption.place}&status=${detailOption.status}&tag=${detailOption.tag}`, 
-  isLogin ? (url: string) => axiosInstance.get(url).then((res) => res.data)
-    : defaultGetFetcher, {
+  const { data, isValidating, error, mutate } = useSWR<IPagination<IPost[]>>(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=${type}&sort=${sort}&page=${page}&pageSize=${pageSize}&keyword=${keyword}&due=${detailOption.due}&region=${detailOption.place}&place=${detailOption.place}&status=${detailOption.status}&tag=${detailOption.tag}`,
+    isLogin ? (url: string) => axiosInstance.get(url).then((res) => res.data)
+      : defaultGetFetcher, {
     fallbackData: initData,
   })
-  const pageLimit = data?.totalPages
+
+  console.log("data?.totalPages", data?.totalPages);
+  const pageLimit = data?.totalPages ?? 1
   const { target, spinner } = useInfiniteScroll({
     setPage,
     mutate,
     pageLimit,
     page,
   })
+  console.log("data", data);
 
   return (
     <>
@@ -84,7 +88,7 @@ const MainPage = ({ initData }: { initData: IPost[] }) => {
               </Stack>
             </Grid>
           </Grid>
-          {isLoading ? (
+          {isValidating ? (
             <Typography>로딩중...</Typography>
           ) : error ? (
             <Typography>에러 발생</Typography>
@@ -149,7 +153,7 @@ const MainPage = ({ initData }: { initData: IPost[] }) => {
                 </Stack>
               </Grid>
             </Grid>
-            {isLoading ? (
+            {isValidating ? (
               <Typography>로딩중...</Typography>
             ) : error ? (
               <Typography>에러 발생</Typography>

--- a/src/app/panel/MainPage.tsx
+++ b/src/app/panel/MainPage.tsx
@@ -51,11 +51,15 @@ const MainPage = ({ initData }: { initData: IPagination<IPost[]> }) => {
   // useswr의 초기값을 initdata로 설정하려했으나 실패. 지금 코드는 초기에 서버와 클라이언트 둘다 리퀘스트를 보내게 됨
   const pageSize = 5
 
-  const { data, isValidating, error, mutate } = useSWR<IPagination<IPost[]>>(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=${type}&sort=${sort}&page=${page}&pageSize=${pageSize}&keyword=${keyword}&due=${detailOption.due}&region1=${detailOption.region1}&region2=${detailOption.region2}&place=${detailOption.place}&status=${detailOption.status}&tag=${detailOption.tag}`,
-    isLogin ? (url: string) => axiosInstance.get(url).then((res) => res.data)
-      : defaultGetFetcher, {
-    fallbackData: initData,
-  })
+  const { data, isValidating, error, mutate } = useSWR<IPagination<IPost[]>>(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit?type=${type}&sort=${sort}&page=${page}&pageSize=${pageSize}&keyword=${keyword}&due=${detailOption.due}&region1=${detailOption.region1}&region2=${detailOption.region2}&place=${detailOption.place}&status=${detailOption.status}&tag=${detailOption.tag}`,
+    isLogin
+      ? (url: string) => axiosInstance.get(url).then((res) => res.data)
+      : defaultGetFetcher,
+    {
+      fallbackData: initData,
+    },
+  )
   const pageLimit = data?.totalPages ?? 1
   const { target, spinner } = useInfiniteScroll({
     setPage,

--- a/src/app/panel/MainProfile.tsx
+++ b/src/app/panel/MainProfile.tsx
@@ -8,10 +8,8 @@ const MainProfile = () => {
   const axiosWithAuth = useAxiosWithAuth()
   const { isLogin } = useAuthStore()
   const { data } = useSWR<IUserProfile>(
-    isLogin
-      ? `${process.env.NEXT_PUBLIC_API_URL}/api/v1/profile`
-      : undefined,
-      (url: string) => axiosWithAuth.get(url).then((res) => res.data)
+    isLogin ? `${process.env.NEXT_PUBLIC_API_URL}/api/v1/profile` : undefined,
+    (url: string) => axiosWithAuth.get(url).then((res) => res.data),
   )
 
   return (

--- a/src/app/panel/Options.tsx
+++ b/src/app/panel/Options.tsx
@@ -70,9 +70,9 @@ const Options = ({ setDetailOption }: { setDetailOption: any }) => {
     }
 
     const status = makeCommaString({
-      before: statusBefore,
-      onGoing: statusonGoing,
-      done: statusdone,
+      BEFORE: statusBefore,
+      ONGOING: statusonGoing,
+      AFTER: statusdone,
     })
 
     const place = makeCommaString({

--- a/src/app/panel/Options.tsx
+++ b/src/app/panel/Options.tsx
@@ -1,12 +1,19 @@
-import {Box, Button, FormGroup, Grid, SelectChangeEvent, Stack,} from '@mui/material'
+import {
+  Box,
+  Button,
+  FormGroup,
+  Grid,
+  SelectChangeEvent,
+  Stack,
+} from '@mui/material'
 
-import {useState} from 'react'
-import {useForm} from 'react-hook-form'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
 import FormCheckbox from './FormCheckbox'
 import TagAutoComplete from '@/components/TagAutoComplete'
 import SetupSelect from '../teams/@setting/[id]/panel/SetupSelect'
-import useSWR from "swr";
-import {defaultGetFetcher} from "@/api/fetchers";
+import useSWR from 'swr'
+import { defaultGetFetcher } from '@/api/fetchers'
 
 const Options = ({ setDetailOption }: { setDetailOption: any }) => {
   const { handleSubmit, control, reset } = useForm({
@@ -19,20 +26,18 @@ const Options = ({ setDetailOption }: { setDetailOption: any }) => {
       statusdone: false,
     },
   })
-  const { data: listData } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/allTags`, defaultGetFetcher)
-    const [due, setDue] = useState('');
+  const { data: listData } = useSWR(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/allTags`,
+    defaultGetFetcher,
+  )
+  const [due, setDue] = useState('')
   const [tagData, setTagData] = useState<string[]>([])
   const [location, setLocation] = useState<string>('')
   const [parentLocation, setParentLocation] = useState<string>('선택안함')
 
   const onSubmit = (data: any) => {
-    const {
-      placeOnline,
-      placeOffline,
-      placemix,
-      statusonGoing,
-      statusdone,
-    } = data
+    const { placeOnline, placeOffline, placemix, statusonGoing, statusdone } =
+      data
 
     const makeCommaString = (obj: { [key: string]: boolean }) => {
       const trueKeys = Object.keys(obj).filter((key) => obj[key])
@@ -40,21 +45,20 @@ const Options = ({ setDetailOption }: { setDetailOption: any }) => {
     }
 
     const status = makeCommaString({
-      "ONGOING": statusonGoing,
-      "DONE": statusdone,
+      ONGOING: statusonGoing,
+      DONE: statusdone,
     })
 
     const place = makeCommaString({
-      "ONLINE": placeOnline,
-      "OFFLINE": placeOffline,
-      "MIX": placemix
+      ONLINE: placeOnline,
+      OFFLINE: placeOffline,
+      MIX: placemix,
     })
 
     const tag = tagData.length ? tagData.join(',') : ''
     setDetailOption({
-      due: due === "선택안함" ? '' : due,
-      region1:
-        parentLocation === '선택안함' ? '' : parentLocation,
+      due: due === '선택안함' ? '' : due,
+      region1: parentLocation === '선택안함' ? '' : parentLocation,
       region2: parentLocation === '선택안함' ? '' : location,
       place,
       status,
@@ -76,9 +80,7 @@ const Options = ({ setDetailOption }: { setDetailOption: any }) => {
         <Grid item xs={12}>
           <Box>작업 스택</Box>
           <TagAutoComplete
-            list={listData?.map(({name}: {name: string}) => (
-                name
-            ))}
+            list={listData?.map(({ name }: { name: string }) => name)}
             datas={tagData}
             setData={setTagData}
           />
@@ -86,11 +88,9 @@ const Options = ({ setDetailOption }: { setDetailOption: any }) => {
         <Grid item xs={12} sm={6}>
           <Box>목표 기간</Box>
           <SetupSelect
-              value={due}
-              setValue={(event: SelectChangeEvent) =>
-                  setDue(event.target.value)
-              }
-              type="dueToSearch"
+            value={due}
+            setValue={(event: SelectChangeEvent) => setDue(event.target.value)}
+            type="dueToSearch"
           />
         </Grid>
         <Grid item xs={12} sm={6}>

--- a/src/app/recruitment/[id]/page.tsx
+++ b/src/app/recruitment/[id]/page.tsx
@@ -41,23 +41,15 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
     isLogin ? (url: string) => axiosInstance.get(url).then((res) => res.data)
       : defaultGetFetcher)
 
-  const { data: userData } = useSWR<{
-    nickname: string
-    profileImageUrl: string
-  }>(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/profile/other/?userId=${data?.user_id}?infoList=profileImageUrl&infoList=nickname`,
-    defaultGetFetcher,
-  )
-
   const total = useMemo(() => {
     if (!data) return 0
-    return data.role.reduce((acc, cur) => {
+    return data?.roleList?.reduce((acc, cur) => {
       return acc + cur.number
     }, 0)
   }, [data])
 
   const handleApply = (selectedRole: string) => {
-    if (isLogin)
+    if (!isLogin)
       router.push("/login")
     else {
       setRole(selectedRole)
@@ -75,7 +67,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
       <RecruitFormModal
         open={open}
         setOpen={setOpen}
-        post_id={params.id}
+        recruit_id={params.id}
         role={role}
         user_id={data?.user_id}
       />
@@ -83,7 +75,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
         <Container>
           <Stack direction={'row'} gap={4} marginBottom={6}>
             <Image
-              src={userData?.profileImageUrl ?? ''}
+              src={data?.user_thumbnail ?? ''}
               alt="leader_profile"
               width={300}
               height={300}
@@ -94,7 +86,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
                 <Chip label={data?.status} size="medium" />
               </Stack>
               <Stack gap={2} direction="row">
-                <Typography>{userData?.nickname}</Typography>
+                <Typography>{data?.user_nickname}</Typography>
                 <Typography>
                   {type === 'project' ? '프로젝트' : '스터디'}
                 </Typography>
@@ -111,17 +103,19 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
                 <LinkButton href={data?.link} />
               </Stack>
               <ApplyButton
-                role={data?.role?.map((item) => item.name) || []}
+                role={data?.roleList?.map((item) => item.name) || []}
                 onApply={handleApply}
               />
             </Box>
           </Stack>
-          <RecruitFormText label="총 인원" content={total?.toString() ?? '0'} />
+          <RecruitFormText label="총 인원" content={(total?.toString() ?? '0') + " 명"} />
           <RecruitFormText label="목표 작업기간" content={data?.due} />
-          <RecruitFormText label="지역" content={data?.region} />
+          <RecruitFormText label="지역" >
+            {data?.region ? <Typography>{data.region[0] + " " + data.region?.[1]}</Typography> : <Typography>없음</Typography>}
+          </RecruitFormText>
           <RecruitFormText label="역할">
             <Box>
-              {data?.role?.map(({ name, number }, idx: number) => (
+              {data?.roleList?.map(({ name, number }, idx: number) => (
                 <Chip label={`${name} ${number} 명`} size="small" key={idx} />
               ))}
             </Box>
@@ -139,7 +133,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
               ))}
             </Box>
           </RecruitFormText>
-        </Container>
+        </Container >
       ) : (
         <>
           <Drawer
@@ -148,7 +142,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
             onClose={() => setRoleOpen(false)}
           >
             <List>
-              {data?.role.map(({ name }) => (
+              {data?.roleList.map(({ name }) => (
                 <ListItem key={name}>
                   <ListItemButton onClick={() => handleApply(name)}>
                     {name}
@@ -160,24 +154,24 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
           <Typography variant="h5">{data?.title}</Typography>
           <Chip label={data?.status} size="medium" />
           <Stack gap={2} direction="row">
-            <Typography>{userData?.nickname}</Typography>
+            <Typography>{data?.user_nickname}</Typography>
             <Typography>
               {type === 'project' ? '프로젝트' : '스터디'}
             </Typography>
             <Typography>{data?.place}</Typography>
           </Stack>
           <Image
-            src={userData?.profileImageUrl ?? ''}
+            src={data?.user_thumbnail ?? ''}
             alt="leader_profile"
             width={300}
             height={300}
           />
-          <RecruitFormText label="총 인원" content={total?.toString() ?? '0'} />
+          <RecruitFormText label="총 인원" content={(total?.toString() ?? '0') + " 명"} />
           <RecruitFormText label="목표 작업기간" content={data?.due} />
           <RecruitFormText label="지역" content={data?.region} />
           <RecruitFormText label="역할">
             <Box>
-              {data?.role?.map(({ name, number }, idx: number) => (
+              {data?.roleList?.map(({ name, number }, idx: number) => (
                 <Chip label={`${name} ${number} 명`} size="small" key={idx} />
               ))}
             </Box>
@@ -201,7 +195,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
             variant="contained"
             size="large"
             onClick={() => {
-              if (isLogin)
+              if (!isLogin)
                 router.push("/login")
               else
                 setRoleOpen(true)

--- a/src/app/recruitment/[id]/page.tsx
+++ b/src/app/recruitment/[id]/page.tsx
@@ -180,7 +180,13 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
             content={(total?.toString() ?? '0') + ' 명'}
           />
           <RecruitFormText label="목표 작업기간" content={data?.due} />
-          <RecruitFormText label="지역" content={data?.region} />
+          <RecruitFormText label="지역">
+            {data?.region ? (
+              <Typography>{data.region[0] + ' ' + data.region?.[1]}</Typography>
+            ) : (
+              <Typography>없음</Typography>
+            )}
+          </RecruitFormText>
           <RecruitFormText label="역할">
             <Box>
               {data?.roleList?.map(({ name, number }, idx: number) => (

--- a/src/app/recruitment/[id]/page.tsx
+++ b/src/app/recruitment/[id]/page.tsx
@@ -37,9 +37,12 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
   const { isLogin } = useAuthStore()
   const axiosInstance = useAxiosWithAuth()
 
-  const { data, isLoading, error } = useSWR<IPostDetail>(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/${params.id}`,
-    isLogin ? (url: string) => axiosInstance.get(url).then((res) => res.data)
-      : defaultGetFetcher)
+  const { data, isLoading, error } = useSWR<IPostDetail>(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/${params.id}`,
+    isLogin
+      ? (url: string) => axiosInstance.get(url).then((res) => res.data)
+      : defaultGetFetcher,
+  )
 
   const total = useMemo(() => {
     if (!data) return 0
@@ -49,8 +52,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
   }, [data])
 
   const handleApply = (selectedRole: string) => {
-    if (!isLogin)
-      router.push("/login")
+    if (!isLogin) router.push('/login')
     else {
       setRole(selectedRole)
       setRoleOpen(false)
@@ -108,10 +110,17 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
               />
             </Box>
           </Stack>
-          <RecruitFormText label="총 인원" content={(total?.toString() ?? '0') + " 명"} />
+          <RecruitFormText
+            label="총 인원"
+            content={(total?.toString() ?? '0') + ' 명'}
+          />
           <RecruitFormText label="목표 작업기간" content={data?.due} />
-          <RecruitFormText label="지역" >
-            {data?.region ? <Typography>{data.region[0] + " " + data.region?.[1]}</Typography> : <Typography>없음</Typography>}
+          <RecruitFormText label="지역">
+            {data?.region ? (
+              <Typography>{data.region[0] + ' ' + data.region?.[1]}</Typography>
+            ) : (
+              <Typography>없음</Typography>
+            )}
           </RecruitFormText>
           <RecruitFormText label="역할">
             <Box>
@@ -133,7 +142,7 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
               ))}
             </Box>
           </RecruitFormText>
-        </Container >
+        </Container>
       ) : (
         <>
           <Drawer
@@ -166,7 +175,10 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
             width={300}
             height={300}
           />
-          <RecruitFormText label="총 인원" content={(total?.toString() ?? '0') + " 명"} />
+          <RecruitFormText
+            label="총 인원"
+            content={(total?.toString() ?? '0') + ' 명'}
+          />
           <RecruitFormText label="목표 작업기간" content={data?.due} />
           <RecruitFormText label="지역" content={data?.region} />
           <RecruitFormText label="역할">
@@ -195,10 +207,8 @@ const RecruitDetailPage = ({ params }: { params: { id: string } }) => {
             variant="contained"
             size="large"
             onClick={() => {
-              if (!isLogin)
-                router.push("/login")
-              else
-                setRoleOpen(true)
+              if (!isLogin) router.push('/login')
+              else setRoleOpen(true)
             }}
           >
             지원하기

--- a/src/app/recruitment/[id]/panel/RecruitFormModal.tsx
+++ b/src/app/recruitment/[id]/panel/RecruitFormModal.tsx
@@ -15,6 +15,7 @@ import CheckQuestionForm, { CheckQuestionList } from './CheckQuestionForm'
 import RatioQuestionForm, { RatioQuestionList } from './RatioQuestionForm'
 import useAxiosWithAuth from '@/api/config'
 import useSWR from 'swr'
+import useAuthStore from "@/states/useAuthStore";
 interface IInterviewData {
   question: string
   type: 'CLOSE' | 'OPEN' | 'RATIO' | 'CHECK'
@@ -35,9 +36,10 @@ const RecruitFormModal = ({
   role: string
 }) => {
   const axiosWithAuth = useAxiosWithAuth()
+  const { isLogin } = useAuthStore()
 
-  const { data } = useSWR<IInterviewData[]>(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/interview/${recruit_id}`,
+  const { data } = useSWR<IInterviewData[]>(isLogin ?
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/interview/${recruit_id}` : null,
     (url: string) => axiosWithAuth.get(url).then((res) => res.data),
   )
 

--- a/src/app/recruitment/[id]/panel/RecruitFormModal.tsx
+++ b/src/app/recruitment/[id]/panel/RecruitFormModal.tsx
@@ -15,7 +15,7 @@ import CheckQuestionForm, { CheckQuestionList } from './CheckQuestionForm'
 import RatioQuestionForm, { RatioQuestionList } from './RatioQuestionForm'
 import useAxiosWithAuth from '@/api/config'
 import useSWR from 'swr'
-import useAuthStore from "@/states/useAuthStore";
+import useAuthStore from '@/states/useAuthStore'
 interface IInterviewData {
   question: string
   type: 'CLOSE' | 'OPEN' | 'RATIO' | 'CHECK'
@@ -38,8 +38,10 @@ const RecruitFormModal = ({
   const axiosWithAuth = useAxiosWithAuth()
   const { isLogin } = useAuthStore()
 
-  const { data } = useSWR<IInterviewData[]>(isLogin ?
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/interview/${recruit_id}` : null,
+  const { data } = useSWR<IInterviewData[]>(
+    isLogin
+      ? `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/interview/${recruit_id}`
+      : null,
     (url: string) => axiosWithAuth.get(url).then((res) => res.data),
   )
 
@@ -65,7 +67,6 @@ const RecruitFormModal = ({
   const submitForm = () => {
     handleSubmit(onSubmit)()
   }
-
 
   const onSubmit = async (values: any) => {
     const array = Object.values(values)

--- a/src/app/recruitment/[id]/panel/RecruitFormModal.tsx
+++ b/src/app/recruitment/[id]/panel/RecruitFormModal.tsx
@@ -17,7 +17,7 @@ import useAxiosWithAuth from '@/api/config'
 import useSWR from 'swr'
 interface IInterviewData {
   question: string
-  type: 'close' | 'open' | 'ratio' | 'check'
+  type: 'CLOSE' | 'OPEN' | 'RATIO' | 'CHECK'
   optionList?: CloseQuestionList | RatioQuestionList | CheckQuestionList | null
 }
 
@@ -25,20 +25,20 @@ const RecruitFormModal = ({
   open,
   setOpen,
   user_id,
-  post_id,
+  recruit_id,
   role,
 }: {
   open: boolean
   setOpen: any
   user_id: string
-  post_id: string
+  recruit_id: string
   role: string
 }) => {
   const axiosWithAuth = useAxiosWithAuth()
 
   const { data } = useSWR<IInterviewData[]>(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/interview/${post_id}`,
-      (url: string) => axiosWithAuth.get(url).then((res) => res.data),
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recruit/interview/${recruit_id}`,
+    (url: string) => axiosWithAuth.get(url).then((res) => res.data),
   )
 
   const [openConfirm, setOpenConfirm] = useState(false)
@@ -63,7 +63,7 @@ const RecruitFormModal = ({
   const submitForm = () => {
     handleSubmit(onSubmit)()
   }
-  
+
 
   const onSubmit = async (values: any) => {
     const array = Object.values(values)
@@ -79,7 +79,7 @@ const RecruitFormModal = ({
 
     const value = {
       user_id,
-      post_id,
+      recruit_id,
       role,
       answerList,
     }
@@ -87,7 +87,7 @@ const RecruitFormModal = ({
 
     try {
       await axiosWithAuth.post(
-        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recriut/interview/${post_id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/recriut/interview/${recruit_id}`,
         value,
       )
       setOpenConfirm(false)
@@ -136,7 +136,7 @@ const RecruitFormModal = ({
               <Box key={idx}>
                 <Typography>{idx + 1}번 질문</Typography>
                 <Typography>{quest.question}</Typography>
-                {quest.type === 'open' && (
+                {quest.type === 'OPEN' && (
                   <Controller
                     rules={{
                       required: '답변을 입력해주세요',
@@ -147,7 +147,7 @@ const RecruitFormModal = ({
                     render={({ field }) => <TextField {...field} />}
                   />
                 )}
-                {quest.type === 'close' && (
+                {quest.type === 'CLOSE' && (
                   <CloseQuestionForm
                     optionList={quest?.optionList as CloseQuestionList}
                     control={control}
@@ -155,7 +155,7 @@ const RecruitFormModal = ({
                     disabled={false}
                   />
                 )}
-                {quest.type === 'ratio' && (
+                {quest.type === 'RATIO' && (
                   <RatioQuestionForm
                     optionList={quest?.optionList as RatioQuestionList}
                     control={control}
@@ -163,7 +163,7 @@ const RecruitFormModal = ({
                     disabled={false}
                   />
                 )}
-                {quest.type === 'check' && (
+                {quest.type === 'CHECK' && (
                   <CheckQuestionForm
                     optionList={quest?.optionList as CheckQuestionList}
                     control={control}

--- a/src/app/recruitment/[id]/panel/RecruitFormText.tsx
+++ b/src/app/recruitment/[id]/panel/RecruitFormText.tsx
@@ -1,6 +1,6 @@
 import { Typography } from "@mui/material";
 
-const RecruitFormText = ({ label, content, children }: { label: string, content?: string, children?: React.ReactNode }) => (
+const RecruitFormText = ({ label, content, children }: { label: string, content?: string | string[], children?: React.ReactNode }) => (
     <>
         <Typography sx={{ fontWeight: 'bold' }}>{label}</Typography>
         {content && <Typography>{content}</Typography>}

--- a/src/app/recruitment/[id]/panel/RecruitFormText.tsx
+++ b/src/app/recruitment/[id]/panel/RecruitFormText.tsx
@@ -6,7 +6,7 @@ const RecruitFormText = ({
   children,
 }: {
   label: string
-  content?: string | string[]
+  content?: string
   children?: React.ReactNode
 }) => (
   <>

--- a/src/app/recruitment/[id]/panel/RecruitFormText.tsx
+++ b/src/app/recruitment/[id]/panel/RecruitFormText.tsx
@@ -1,11 +1,19 @@
-import { Typography } from "@mui/material";
+import { Typography } from '@mui/material'
 
-const RecruitFormText = ({ label, content, children }: { label: string, content?: string | string[], children?: React.ReactNode }) => (
-    <>
-        <Typography sx={{ fontWeight: 'bold' }}>{label}</Typography>
-        {content && <Typography>{content}</Typography>}
-        {children && children}
-    </>
+const RecruitFormText = ({
+  label,
+  content,
+  children,
+}: {
+  label: string
+  content?: string | string[]
+  children?: React.ReactNode
+}) => (
+  <>
+    <Typography sx={{ fontWeight: 'bold' }}>{label}</Typography>
+    {content && <Typography>{content}</Typography>}
+    {children && children}
+  </>
 )
 
-export default RecruitFormText;
+export default RecruitFormText

--- a/src/app/teams/@setting/[id]/panel/SetupSelect.tsx
+++ b/src/app/teams/@setting/[id]/panel/SetupSelect.tsx
@@ -103,7 +103,49 @@ export const SetupSelect = ({
         </Select>
       </FormControl>
     )
-  } else {
+  } else if (type == "dueToSearch") {
+      {
+          return (
+              <FormControl sx={{ m: 0, minWidth: 80 }} size="small">
+                  <InputLabel id="demo-select-small-label">목표 기간</InputLabel>
+                  <Select
+                      labelId="demo-select-small-label"
+                      id="demo-select-small"
+                      value={value}
+                      label="목표 기간"
+                      onChange={setValue}
+                      defaultValue={'선택안함'}
+                  >
+                      {[
+                          '선택안함',
+                          '1주일',
+                          '2주일',
+                          '3주일',
+                          '4주일',
+                          '1개월',
+                          '2개월',
+                          '3개월',
+                          '4개월',
+                          '5개월',
+                          '6개월',
+                          '7개월',
+                          '8개월',
+                          '9개월',
+                          '10개월',
+                          '11개월',
+                          '12개월',
+                          '12개월 이상',
+                      ].map((dueTo, idx) => (
+                          <MenuItem key={'dueTo' + idx} value={dueTo}>
+                              {dueTo}
+                          </MenuItem>
+                      ))}
+                  </Select>
+              </FormControl>
+          )
+      }
+  }
+  else {
     return <div></div>
   }
 }

--- a/src/types/IPagination.ts
+++ b/src/types/IPagination.ts
@@ -1,0 +1,28 @@
+export interface IPagination<T> {
+  content: T
+  pageable: {
+    sort: {
+      empty: boolean
+      unsorted: boolean
+      sorted: boolean
+    }
+    offset: number
+    pageNumber: number
+    pageSize: number
+    paged: boolean
+    unpaged: boolean
+  }
+  totalPages: number
+  totalElements: number
+  last: boolean
+  size: number
+  number: number
+  sort: {
+    empty: boolean
+    unsorted: boolean
+    sorted: boolean
+  }
+  numberOfElements: number
+  first: boolean
+  empty: boolean
+}

--- a/src/types/IPostDetail.ts
+++ b/src/types/IPostDetail.ts
@@ -4,7 +4,7 @@ export interface ITag {
 }
 
 export interface IPost {
-  post_id: number
+  recruit_id: number
   title: string
   image: string
   user_id: string
@@ -12,20 +12,22 @@ export interface IPost {
   user_thumbnail: string
   status: string
   tagList: ITag[]
-  isFavorite: boolean
+  favorite: boolean
 }
 
 export interface IPostDetail {
   title: string
-  status: string
+  status: TPostStatus
   due: string
   content: string
   user_id: string
-  region: string
+  user_nickname: string
+  user_thumbnail: string
+  region: string[]
   link: string
   tagList: ITag[]
-  role: IRole[]
-  interviewList: IFormInterview[]
+  roleList: IRole[]
+  // interviewList: IFormInterview[]
   place: string
 }
 
@@ -39,6 +41,8 @@ export interface IRole {
   name: string
   number: number
 }
+
+export type TPostStatus = 'BEFORE' | 'ONGOING' | 'AFTER'
 
 export enum statusEnum {
   BEFORE,

--- a/src/types/IPostDetail.ts
+++ b/src/types/IPostDetail.ts
@@ -42,7 +42,7 @@ export interface IRole {
   number: number
 }
 
-export type TPostStatus = 'BEFORE' | 'ONGOING' | 'AFTER'
+export type TPostStatus = 'BEFORE' | 'ONGOING' | 'DONE'
 
 export enum statusEnum {
   BEFORE,


### PR DESCRIPTION
**어제 api 연동에 성공했고, 이에 따라 생기는 여러 문제를 해결했습니다.** 
- 변수명을 백엔드의 dto에 따라 수정했습니다
- 요청 url도 일부수정했습니다.
- 메인페이지의 카드 컴포넌트의 관심글 기능과 이동 기능이 같이 작동할 수 있도록 하기 위해, Link가 감싸고있는 범위를 쪼갰습니다. (관심글 기능은 LInk가 적용되지 않도록)
- 세부옵션의 경우, 가능한 작업스택 목록을 불러오는 TagData api가 새로 생겨 적용했습니다.
- 통일성을 위해, 세부옵션에서 목표 기간 선택 부분을 팀 페이지에서 사용하는 SetupSelect 컴포넌트로 일단 대체했습니다 (추후 변경 사항이 있으면 같이 수정하겠습니다)
- IPagination라는 interface를 만들었습니다. 백엔드에서 pagination을 이용해 가져오는 data의 인터페이스입니다

**아직 완벽하게 세부 옵션 검색이 작동하지는 않습니다. 이 부분 백엔드와 확인 후 다시 수정될 예정입니다

참고 이슈
https://github.com/peer-42seoul/Peer-Frontend/issues/243
https://github.com/peer-42seoul/Peer-Frontend/issues/202