### PR TITLE
[FIX] 로그인 상태에서 회원가입 접근 막기 및 회원 탈퇴 후 Zustand Login 상태 초기화

### DIFF
--- a/src/app/my-page/privacy/panel/UserWithdrawalModal.tsx
+++ b/src/app/my-page/privacy/panel/UserWithdrawalModal.tsx
@@ -4,6 +4,7 @@ import CuModal from '@/components/CuModal'
 
 import { useState, Dispatch, SetStateAction } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
+import useAuthStore from '@/states/useAuthStore'
 import useAxiosWithAuth from '@/api/config'
 import IToastProps from '@/types/IToastProps'
 import LocalStorage from '@/states/localStorage'
@@ -48,6 +49,10 @@ const UserWithdrawalModal = ({
       })
       LocalStorage.removeItem('authData')
       removeCookie('refreshToken', { path: '/' })
+      useAuthStore.setState({
+        isLogin: false,
+        accessToken: null,
+      })
       alert('계정이 삭제되었습니다')
       handleClose()
       router.push('/')

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import useAuthStore from '@/states/useAuthStore'
 
 const PCLoginBox = {
   display: 'flex',
@@ -54,6 +55,12 @@ const Privacy = () => {
   const [checkStatus, setCheckStatus] = useState<boolean[]>([false, false])
   const [disabled, setDisabled] = useState<boolean>(true)
   const router = useRouter()
+
+  // 로그인 상태일 경우 메인 페이지로 이동
+  useEffect(() => {
+    const isLogin = useAuthStore.getState().isLogin
+    if (isLogin) router.replace('/')
+  }, [])
 
   useEffect(() => {
     if (!checkStatus[0] || !checkStatus[1]) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-
+import { useState, useEffect } from 'react'
+import useAuthStore from '@/states/useAuthStore'
 import { Button, Typography, Box } from '@mui/material'
 import axios from 'axios'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -66,6 +66,12 @@ const SignUp = () => {
     },
     mode: 'onChange',
   })
+
+  // 로그인 상태일 경우 메인 페이지로 이동
+  useEffect(() => {
+    const isLogin = useAuthStore.getState().isLogin
+    if (isLogin) router.replace('/')
+  }, [])
 
   const [signUpStep, setSignUpStep] = useState<number>(0)
   const [emailSendStatus, setEmailSendStatus] = useState<


### PR DESCRIPTION
-  #292 로그인 상태에서 회원가입 페이지로 진입하지 못하게 했습니다.
- #294 회원 탈퇴 시 전역 상태에서 로그인 상태가 지속됐는데 전역 상태에서 로그인 토큰를 null로 isLogin 변수를 false로 초기화 시켰습니다.  