### PR TITLE
[A-JOI] Oauth 회원가입 시 개인정보 동의란으로 이동

### DIFF
--- a/src/app/my-page/privacy/panel/UserWithdrawalModal.tsx
+++ b/src/app/my-page/privacy/panel/UserWithdrawalModal.tsx
@@ -4,6 +4,7 @@ import CuModal from '@/components/CuModal'
 
 import { useState, Dispatch, SetStateAction } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
+import useAuthStore from '@/states/useAuthStore'
 import useAxiosWithAuth from '@/api/config'
 import IToastProps from '@/types/IToastProps'
 import LocalStorage from '@/states/localStorage'
@@ -48,6 +49,10 @@ const UserWithdrawalModal = ({
       })
       LocalStorage.removeItem('authData')
       removeCookie('refreshToken', { path: '/' })
+      useAuthStore.setState({
+        isLogin: false,
+        accessToken: null,
+      })
       alert('계정이 삭제되었습니다')
       handleClose()
       router.push('/')

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -10,7 +10,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import useAuthStore from '@/states/useAuthStore'
 
@@ -55,6 +55,8 @@ const Privacy = () => {
   const [checkStatus, setCheckStatus] = useState<boolean[]>([false, false])
   const [disabled, setDisabled] = useState<boolean>(true)
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const socialEmail = searchParams.get('social-email')
 
   // 로그인 상태일 경우 메인 페이지로 이동
   useEffect(() => {
@@ -72,7 +74,10 @@ const Privacy = () => {
   }, [checkStatus])
 
   const onClick = () => {
-    if (checkStatus[0] && checkStatus[1]) router.push('/signup')
+    if (checkStatus[0] && checkStatus[1])
+      router.push(
+        socialEmail ? '/signup' + '?social-email=' + socialEmail : '/signup',
+      )
   }
 
   return (

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import useAuthStore from '@/states/useAuthStore'
 
 const PCLoginBox = {
   display: 'flex',
@@ -54,6 +55,12 @@ const Privacy = () => {
   const [checkStatus, setCheckStatus] = useState<boolean[]>([false, false])
   const [disabled, setDisabled] = useState<boolean>(true)
   const router = useRouter()
+
+  // 로그인 상태일 경우 메인 페이지로 이동
+  useEffect(() => {
+    const isLogin = useAuthStore.getState().isLogin
+    if (isLogin) router.replace('/')
+  }, [])
 
   useEffect(() => {
     if (!checkStatus[0] || !checkStatus[1]) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-
+import { useState, useEffect } from 'react'
+import useAuthStore from '@/states/useAuthStore'
 import { Button, Typography, Box } from '@mui/material'
 import axios from 'axios'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -66,6 +66,12 @@ const SignUp = () => {
     },
     mode: 'onChange',
   })
+
+  // 로그인 상태일 경우 메인 페이지로 이동
+  useEffect(() => {
+    const isLogin = useAuthStore.getState().isLogin
+    if (isLogin) router.replace('/')
+  }, [])
 
   const [signUpStep, setSignUpStep] = useState<number>(0)
   const [emailSendStatus, setEmailSendStatus] = useState<


### PR DESCRIPTION
- Oauth 회원가입 시에도 개인정보 동의가 필요해서 백엔드에서 오는 url이 개인정보 동의란 페이지로 변경되었습니다. 
- Oauth 정보가 쿼리 스트링으로 넘어오는데 회원가입 페이지에서 이게 필요해서 개인정보 동의란 페이지에서 Oauth 회원가입페이지로 쿼리 스트링을 넘겨주는 로직을 작성했습니다.