### PR TITLE
[A-JOI] Oauth 회원가입 시 개인정보 동의란으로 이동

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -10,7 +10,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 const PCLoginBox = {
@@ -54,6 +54,8 @@ const Privacy = () => {
   const [checkStatus, setCheckStatus] = useState<boolean[]>([false, false])
   const [disabled, setDisabled] = useState<boolean>(true)
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const socialEmail = searchParams.get('social-email')
 
   useEffect(() => {
     if (!checkStatus[0] || !checkStatus[1]) {
@@ -65,7 +67,10 @@ const Privacy = () => {
   }, [checkStatus])
 
   const onClick = () => {
-    if (checkStatus[0] && checkStatus[1]) router.push('/signup')
+    if (checkStatus[0] && checkStatus[1])
+      router.push(
+        socialEmail ? '/signup' + '?social-email=' + socialEmail : '/signup',
+      )
   }
 
   return (


### PR DESCRIPTION
- Oauth 회원가입 시에도 개인정보 동의가 필요해서 백엔드에서 오는 url이 개인정보 동의란 페이지로 변경되었습니다.
- Oauth 정보가 쿼리 스트링으로 넘어오는데 회원가입 페이지에서 이게 필요해서 개인정보 동의란 페이지에서 Oauth 회원가입페이지로 쿼리 스트링을 넘겨주는 로직을 작성했습니다.