### PR TITLE
[C-MYPAGE] 쪽지 전체 선택 / 해제 기능 추가

### DIFF
--- a/src/app/my-page/message/panel/MessageBar.tsx
+++ b/src/app/my-page/message/panel/MessageBar.tsx
@@ -1,0 +1,61 @@
+import CuButton from '@/components/CuButton'
+import { Button, Stack, TextField } from '@mui/material'
+
+interface ISearchBarProps {
+  setSearchKeyword: (keyword: string) => void
+  setIsManageMode: (isManageMode: boolean) => void
+  handleMessageSearch: () => void
+}
+
+export const SearchBar = ({
+  setSearchKeyword,
+  setIsManageMode,
+  handleMessageSearch,
+}: ISearchBarProps) => {
+  return (
+    <Stack direction="row">
+      <TextField
+        placeholder="사람을 검색해 주세요."
+        onChange={(e) => setSearchKeyword(e.target.value)}
+      />
+      <Button variant="contained" onClick={handleMessageSearch}>
+        검색
+      </Button>
+      <CuButton
+        variant="text"
+        action={() => setIsManageMode(true)}
+        message="관리"
+      />
+    </Stack>
+  )
+}
+
+interface IManageBarProps {
+  isSelectedAll: boolean
+  handleSelectAll: () => void
+  handleUnselectAll: () => void
+  handleDelete: () => void
+}
+
+export const ManageBar = ({
+  isSelectedAll,
+  handleSelectAll,
+  handleUnselectAll,
+  handleDelete,
+}: IManageBarProps) => {
+  return (
+    // 관리 모드 나가기 버튼?
+    <Stack direction="row">
+      {isSelectedAll ? (
+        <CuButton
+          variant="text"
+          action={handleUnselectAll}
+          message="전체 선택 해제"
+        />
+      ) : (
+        <CuButton variant="text" action={handleSelectAll} message="전체 선택" />
+      )}
+      <CuButton variant="text" action={handleDelete} message="삭제" />
+    </Stack>
+  )
+}

--- a/src/app/my-page/message/panel/MessageContainer.tsx
+++ b/src/app/my-page/message/panel/MessageContainer.tsx
@@ -41,15 +41,30 @@ const SearchBar = ({
 }
 
 interface IManageBarProps {
+  isSelectAll: boolean
   handleSelectAll: () => void
+  handleUnselectAll: () => void
   handleDelete: () => void
 }
 
-const ManageBar = ({ handleSelectAll, handleDelete }: IManageBarProps) => {
+const ManageBar = ({
+  isSelectAll,
+  handleSelectAll,
+  handleUnselectAll,
+  handleDelete,
+}: IManageBarProps) => {
   return (
     // 관리 모드 나가기 버튼?
     <Stack direction="row">
-      <CuButton variant="text" action={handleSelectAll} message="전체 선택" />
+      {isSelectAll ? (
+        <CuButton
+          variant="text"
+          action={handleUnselectAll}
+          message="전체 선택 해제"
+        />
+      ) : (
+        <CuButton variant="text" action={handleSelectAll} message="전체 선택" />
+      )}
       <CuButton variant="text" action={handleDelete} message="삭제" />
     </Stack>
   )
@@ -73,6 +88,7 @@ const MessageContainer = ({
   // const [selectedUsers, setSelectedUsers] = useState<Set<number>>(new Set())
   const {
     selectedSet: selectedUsers,
+    isSelectedAll,
     selectAll,
     unselectAll,
     toggleSelect,
@@ -128,9 +144,11 @@ const MessageContainer = ({
       <Stack spacing={2}>
         {isManageMode ? (
           <ManageBar
+            isSelectAll={isSelectedAll(messageList)}
             handleSelectAll={() =>
               selectAll(messageList.map((message) => message.targetId))
             }
+            handleUnselectAll={() => unselectAll()}
             handleDelete={handleDelete}
           />
         ) : (

--- a/src/app/my-page/message/panel/MessageContainer.tsx
+++ b/src/app/my-page/message/panel/MessageContainer.tsx
@@ -6,6 +6,7 @@ import { Button, Stack, TextField, Typography } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
 import { IMessageListData } from '@/types/IMessage'
 import CuButton from '@/components/CuButton'
+import useSelectCheckBox from '@/hook/useSelectCheckbox'
 import useToast from '@/hook/useToast'
 import MessageList from './MessageList'
 import useMessageListState from '@/states/useMessageListState'
@@ -69,13 +70,19 @@ const MessageContainer = ({
   const { CuToast, isOpen, openToast, closeToast } = useToast()
   const [isManageMode, setIsManageMode] = useState(false)
   const [searchKeyword, setSearchKeyword] = useState('')
-  const [selectedUsers, setSelectedUsers] = useState<Set<number>>(new Set())
+  // const [selectedUsers, setSelectedUsers] = useState<Set<number>>(new Set())
+  const {
+    selectedSet: selectedUsers,
+    selectAll,
+    unselectAll,
+    toggleSelect,
+  } = useSelectCheckBox(new Set<number>())
 
   const axiosInstance = useAxiosWithAuth()
   const { messageList, setMessageList } = useMessageListState()
 
   useEffect(() => {
-    if (isManageMode) setSelectedUsers(new Set())
+    if (isManageMode) unselectAll()
   }, [isManageMode])
 
   useEffect(() => {
@@ -97,10 +104,6 @@ const MessageContainer = ({
       )
   }, [originalMessageData, searchKeyword])
 
-  const handleSelectAll = () => {
-    setSelectedUsers(new Set(messageList.map((message) => message.targetId)))
-  }
-
   const handleDelete = () => {
     const requestBody = Array.from(selectedUsers).map((targetId) => ({
       targetId,
@@ -120,22 +123,14 @@ const MessageContainer = ({
       })
   }
 
-  const toggleSelectUser = (targetId: number) => {
-    if (selectedUsers.has(targetId)) {
-      selectedUsers.delete(targetId)
-      setSelectedUsers(selectedUsers)
-    } else {
-      selectedUsers.add(targetId)
-      setSelectedUsers(selectedUsers)
-    }
-  }
-
   return (
     <>
       <Stack spacing={2}>
         {isManageMode ? (
           <ManageBar
-            handleSelectAll={handleSelectAll}
+            handleSelectAll={() =>
+              selectAll(messageList.map((message) => message.targetId))
+            }
             handleDelete={handleDelete}
           />
         ) : (
@@ -148,7 +143,7 @@ const MessageContainer = ({
         <MessageList
           messageList={messageList}
           state={{ isManageMode, isLoading, error }}
-          toggleSelectUser={toggleSelectUser}
+          toggleSelectUser={toggleSelect}
         />
         <CuToast open={isOpen} onClose={closeToast} severity="error">
           <Typography>삭제에 실패하였습니다.</Typography>

--- a/src/app/my-page/message/panel/MessageContainer.tsx
+++ b/src/app/my-page/message/panel/MessageContainer.tsx
@@ -2,73 +2,14 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { AxiosResponse } from 'axios'
-import { Button, Stack, TextField, Typography } from '@mui/material'
+import { Stack, Typography } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
 import { IMessageListData } from '@/types/IMessage'
-import CuButton from '@/components/CuButton'
 import useSelectCheckBox from '@/hook/useSelectCheckbox'
 import useToast from '@/hook/useToast'
 import MessageList from './MessageList'
 import useMessageListState from '@/states/useMessageListState'
-
-interface ISearchBarProps {
-  setSearchKeyword: (keyword: string) => void
-  setIsManageMode: (isManageMode: boolean) => void
-  handleMessageSearch: () => void
-}
-
-const SearchBar = ({
-  setSearchKeyword,
-  setIsManageMode,
-  handleMessageSearch,
-}: ISearchBarProps) => {
-  return (
-    <Stack direction="row">
-      <TextField
-        placeholder="사람을 검색해 주세요."
-        onChange={(e) => setSearchKeyword(e.target.value)}
-      />
-      <Button variant="contained" onClick={handleMessageSearch}>
-        검색
-      </Button>
-      <CuButton
-        variant="text"
-        action={() => setIsManageMode(true)}
-        message="관리"
-      />
-    </Stack>
-  )
-}
-
-interface IManageBarProps {
-  isSelectAll: boolean
-  handleSelectAll: () => void
-  handleUnselectAll: () => void
-  handleDelete: () => void
-}
-
-const ManageBar = ({
-  isSelectAll,
-  handleSelectAll,
-  handleUnselectAll,
-  handleDelete,
-}: IManageBarProps) => {
-  return (
-    // 관리 모드 나가기 버튼?
-    <Stack direction="row">
-      {isSelectAll ? (
-        <CuButton
-          variant="text"
-          action={handleUnselectAll}
-          message="전체 선택 해제"
-        />
-      ) : (
-        <CuButton variant="text" action={handleSelectAll} message="전체 선택" />
-      )}
-      <CuButton variant="text" action={handleDelete} message="삭제" />
-    </Stack>
-  )
-}
+import { SearchBar, ManageBar } from './MessageBar'
 
 interface IMessageContainerProps {
   originalMessageData: IMessageListData[] | undefined
@@ -143,11 +84,11 @@ const MessageContainer = ({
       <Stack spacing={2}>
         {isManageMode ? (
           <ManageBar
-            isSelectAll={isSelectedAll(messageList)}
+            isSelectedAll={isSelectedAll(messageList)}
             handleSelectAll={() =>
               selectAll(messageList.map((message) => message.targetId))
             }
-            handleUnselectAll={() => unselectAll()}
+            handleUnselectAll={unselectAll}
             handleDelete={handleDelete}
           />
         ) : (

--- a/src/app/my-page/message/panel/MessageContainer.tsx
+++ b/src/app/my-page/message/panel/MessageContainer.tsx
@@ -85,7 +85,6 @@ const MessageContainer = ({
   const { CuToast, isOpen, openToast, closeToast } = useToast()
   const [isManageMode, setIsManageMode] = useState(false)
   const [searchKeyword, setSearchKeyword] = useState('')
-  // const [selectedUsers, setSelectedUsers] = useState<Set<number>>(new Set())
   const {
     selectedSet: selectedUsers,
     isSelectedAll,
@@ -161,6 +160,7 @@ const MessageContainer = ({
         <MessageList
           messageList={messageList}
           state={{ isManageMode, isLoading, error }}
+          selectedUsers={selectedUsers}
           toggleSelectUser={toggleSelect}
         />
         <CuToast open={isOpen} onClose={closeToast} severity="error">

--- a/src/app/my-page/message/panel/MessageList.tsx
+++ b/src/app/my-page/message/panel/MessageList.tsx
@@ -7,12 +7,14 @@ import { IMessageListData } from '@/types/IMessage'
 interface IMessageItemProps {
   message: IMessageListData
   isManageMode: boolean
+  isChecked: boolean
   toggleSelectUser: (targetId: number) => void
 }
 
 const MessageItem = ({
   message,
   isManageMode,
+  isChecked,
   toggleSelectUser,
 }: IMessageItemProps) => {
   const router = useRouter()
@@ -30,7 +32,11 @@ const MessageItem = ({
   return (
     <Stack direction={'row'} spacing={1}>
       {isManageMode && (
-        <Checkbox {...label} onChange={() => toggleSelectUser(targetId)} />
+        <Checkbox
+          {...label}
+          checked={isChecked}
+          onChange={() => toggleSelectUser(targetId)}
+        />
       )}
       <Grid
         container
@@ -78,12 +84,14 @@ interface IMessageListProps {
     isLoading: boolean
     error: any
   }
+  selectedUsers: Set<number>
   toggleSelectUser: (targetId: number) => void
 }
 
 const MessageList = ({
   messageList,
   state,
+  selectedUsers,
   toggleSelectUser,
 }: IMessageListProps) => {
   const { isManageMode, isLoading, error } = state
@@ -100,6 +108,7 @@ const MessageList = ({
           key={message.targetId}
           message={message}
           isManageMode={isManageMode}
+          isChecked={selectedUsers.has(message.targetId)}
           toggleSelectUser={toggleSelectUser}
         />
       ))}

--- a/src/hook/useSelectCheckbox.tsx
+++ b/src/hook/useSelectCheckbox.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 const useSelectCheckBox = <T,>(initalSet: Set<T>) => {
   const [selectedSet, setSelectedSet] = useState<any>(initalSet)
 
-  const isSelectedAll = (allData: Array<T>) => {
+  const isSelectedAll = (allData: Array<any>) => {
     return allData.length === selectedSet.size
   }
 

--- a/src/hook/useSelectCheckbox.tsx
+++ b/src/hook/useSelectCheckbox.tsx
@@ -3,8 +3,11 @@ import { useState } from 'react'
 const useSelectCheckBox = <T,>(initalSet: Set<T>) => {
   const [selectedSet, setSelectedSet] = useState<any>(initalSet)
 
-  // NOTE : 타입을 지정할 수 있는 방법이 있을까?
-  const selectAll = (allData: any) => {
+  const isSelectedAll = (allData: Array<T>) => {
+    return allData.length === selectedSet.size
+  }
+
+  const selectAll = (allData: Array<T>) => {
     setSelectedSet(new Set(allData))
   }
 
@@ -39,6 +42,7 @@ const useSelectCheckBox = <T,>(initalSet: Set<T>) => {
 
   return {
     selectedSet,
+    isSelectedAll,
     selectAll,
     selectOne,
     unselectAll,

--- a/src/hook/useSelectCheckbox.tsx
+++ b/src/hook/useSelectCheckbox.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
 
-const useSelectCheckBox = () => {
-  const [selectedSet, setSelectedSet] = useState(new Set())
+const useSelectCheckBox = <T,>(initalSet: Set<T>) => {
+  const [selectedSet, setSelectedSet] = useState<any>(initalSet)
 
+  // NOTE : 타입을 지정할 수 있는 방법이 있을까?
   const selectAll = (allData: any) => {
     setSelectedSet(new Set(allData))
   }
 
-  const selectOne = (id: any) => {
+  const selectOne = (id: T) => {
     if (selectedSet.has(id)) return
     const newSet = new Set(selectedSet)
     newSet.add(id)
@@ -18,14 +19,14 @@ const useSelectCheckBox = () => {
     setSelectedSet(new Set())
   }
 
-  const unselectOne = (id: any) => {
+  const unselectOne = (id: T) => {
     if (!selectedSet.has(id)) return
     const newSet = new Set(selectedSet)
     newSet.delete(id)
     setSelectedSet(newSet)
   }
 
-  const toggleSelect = (id: any) => {
+  const toggleSelect = (id: T) => {
     const newSet = new Set(selectedSet)
     if (newSet.has(id)) {
       newSet.delete(id)

--- a/src/hook/useSelectCheckbox.tsx
+++ b/src/hook/useSelectCheckbox.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+
+const useSelectCheckBox = () => {
+  const [selectedSet, setSelectedSet] = useState(new Set())
+
+  const selectAll = (allData: any) => {
+    setSelectedSet(new Set(allData))
+  }
+
+  const selectOne = (id: any) => {
+    if (selectedSet.has(id)) return
+    const newSet = new Set(selectedSet)
+    newSet.add(id)
+    setSelectedSet(newSet)
+  }
+
+  const unselectAll = () => {
+    setSelectedSet(new Set())
+  }
+
+  const unselectOne = (id: any) => {
+    if (!selectedSet.has(id)) return
+    const newSet = new Set(selectedSet)
+    newSet.delete(id)
+    setSelectedSet(newSet)
+  }
+
+  const toggleSelect = (id: any) => {
+    const newSet = new Set(selectedSet)
+    if (newSet.has(id)) {
+      newSet.delete(id)
+      setSelectedSet(newSet)
+    } else {
+      newSet.add(id)
+      setSelectedSet(newSet)
+    }
+  }
+
+  return {
+    selectedSet,
+    selectAll,
+    selectOne,
+    unselectAll,
+    unselectOne,
+    toggleSelect,
+  }
+}
+
+export default useSelectCheckBox

--- a/src/hook/useSelectCheckbox.tsx
+++ b/src/hook/useSelectCheckbox.tsx
@@ -11,22 +11,8 @@ const useSelectCheckBox = <T,>(initalSet: Set<T>) => {
     setSelectedSet(new Set(allData))
   }
 
-  const selectOne = (id: T) => {
-    if (selectedSet.has(id)) return
-    const newSet = new Set(selectedSet)
-    newSet.add(id)
-    setSelectedSet(newSet)
-  }
-
   const unselectAll = () => {
     setSelectedSet(new Set())
-  }
-
-  const unselectOne = (id: T) => {
-    if (!selectedSet.has(id)) return
-    const newSet = new Set(selectedSet)
-    newSet.delete(id)
-    setSelectedSet(newSet)
   }
 
   const toggleSelect = (id: T) => {
@@ -44,9 +30,7 @@ const useSelectCheckBox = <T,>(initalSet: Set<T>) => {
     selectedSet,
     isSelectedAll,
     selectAll,
-    selectOne,
     unselectAll,
-    unselectOne,
     toggleSelect,
   }
 }


### PR DESCRIPTION
### 작업 내용

- SearchBar 컴포넌트와 ManageBar 컴포넌트를 my-page/message/panel/MessageBar.tsx 파일로 뺐습니다.
- 체크박스 전체 선택 / 전체 해제 / 체크 OR 체크 해제 / 모두 선택 여부 확인 기능을 처리하는 useSelectCheckBox 훅을 만들었습니다.
- 전체 선택 / 전체 선택 해제 버튼을 눌렀을 때 체크박스에 표시되도록 수정했습니다. (체크박스의 check property를 직접 지정해줌)

상위 컴포넌트에서 하위 컴포넌트로 내려줘야 하는 내용들이 많아서 전반적으로 컴포넌트들에 props가 너무 많은데 괜찮은 구조인지 잘 모르겠습니다...

<img alt="Screen_Shot 2023-11-14 17 17 19" width="70%" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0d99029c-0d51-4e24-b33f-1edaad8706e1"/>
