### PR TITLE
[FIX] 비밀번호 변경 시 대문자 유효성 검사 에러

### DIFF
--- a/src/app/my-page/privacy/panel/UserInfoEdit.tsx
+++ b/src/app/my-page/privacy/panel/UserInfoEdit.tsx
@@ -103,10 +103,22 @@ export default function UserInfoEdit({
               defaultValue=""
               rules={{
                 required: true,
-                pattern: {
-                  value:
-                    /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/i,
-                  message: '8자 이상의 영문, 숫자, 특수문자 조합이어야 합니다',
+                validate: {
+                  minLength: (value) =>
+                    value.length >= 8 || '비밀번호는 8자 이상이어야 합니다',
+                  maxLength: (value) =>
+                    value.length <= 20 || '비밀번호는 20자 이하여야 합니다',
+                  includeNumber: (value) =>
+                    /\d/.test(value) || '비밀번호에 숫자가 포함되어야 합니다',
+                  includeSpecial: (value) =>
+                    /[!@#$%^&*]/.test(value) ||
+                    '비밀번호에 특수문자가 포함되어야 합니다',
+                  includeCapital: (value) =>
+                    /[A-Z]/.test(value) ||
+                    '비밀번호에 대문자가 포함되어야 합니다',
+                  includeSmall: (value) =>
+                    /[a-z]/.test(value) ||
+                    '비밀번호에 소문자가 포함되어야 합니다',
                 },
               }}
               render={({ field }) => (


### PR DESCRIPTION
- #300 validation 검사에서 대문자를 검증을 못해줘서 패스워드 모든 속성을 각각 따로 유효성 검사 진행하는 로직으로 바꿨습니다.