### PR TITLE
[C-MYPAGE] 쪽지 삭제 기능 개선사항 및 자잘한 개선사항 반영

### DIFF
--- a/src/app/my-page/message/[id]/page.tsx
+++ b/src/app/my-page/message/[id]/page.tsx
@@ -18,8 +18,8 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const searchParams = useSearchParams()
   const [updatedData, setUpdatedData] = useState<IMessage[] | undefined>()
-  const [owner, setOwner] = useState<IMessageUser>()
-  const [target, setTarget] = useState<IMessageTargetUser>()
+  const [owner, setOwner] = useState<IMessageUser | undefined>()
+  const [target, setTarget] = useState<IMessageTargetUser | undefined>()
   const [isEnd, setIsEnd] = useState<boolean>(false)
   const [prevScrollHeight, setPrevScrollHeight] = useState<number | undefined>(
     undefined,
@@ -161,6 +161,7 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
         <MessageForm
           view={'PC_VIEW'}
           targetId={target.userId}
+          updateTarget={setTarget}
           addNewMessage={addNewMessage}
           disabled={target.deleted}
         />

--- a/src/app/my-page/message/[id]/page.tsx
+++ b/src/app/my-page/message/[id]/page.tsx
@@ -9,7 +9,7 @@ import CuButton from '@/components/CuButton'
 import useMedia from '@/hook/useMedia'
 import useModal from '@/hook/useModal'
 import { useMessageInfiniteScroll } from '@/hook/useInfiniteScroll'
-import { IMessage, IMessageUser } from '@/types/IMessage'
+import { IMessage, IMessageUser, IMessageTargetUser } from '@/types/IMessage'
 import MessageItem from './panel/MessageItem'
 import MessageForm from './panel/MessageForm'
 import MessageFormModal from './panel/MessageFormModal'
@@ -19,7 +19,7 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
   const searchParams = useSearchParams()
   const [updatedData, setUpdatedData] = useState<IMessage[] | undefined>()
   const [owner, setOwner] = useState<IMessageUser>()
-  const [target, setTarget] = useState<IMessageUser>()
+  const [target, setTarget] = useState<IMessageTargetUser>()
   const [isEnd, setIsEnd] = useState<boolean>(false)
   const [prevScrollHeight, setPrevScrollHeight] = useState<number | undefined>(
     undefined,
@@ -162,6 +162,7 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
           view={'PC_VIEW'}
           targetId={target.userId}
           addNewMessage={addNewMessage}
+          disabled={target.deleted}
         />
       ) : (
         <>
@@ -170,6 +171,7 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
             action={() => openModal()}
             message="답하기"
             fullWidth
+            disabled={target.deleted}
           />
           <MessageFormModal
             isOpen={isOpen}

--- a/src/app/my-page/message/[id]/page.tsx
+++ b/src/app/my-page/message/[id]/page.tsx
@@ -74,12 +74,10 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
         conversationalId,
       })
       .then((response) => {
-        // TODO : 데이터 순서 논의해보기
-        const reversedData = response.data.msgList.reverse()
-        setUpdatedData(reversedData)
+        setUpdatedData(response.data.msgList)
         setOwner(response.data.msgOwner)
         setTarget(response.data.msgTarget)
-        setIsEnd(reversedData[0].isEnd)
+        setIsEnd(response.data.msgList[0].isEnd)
       })
       .catch(() => {
         // TODO : 에러 구체화
@@ -94,13 +92,11 @@ const MessageChatPage = ({ params }: { params: { id: string } }) => {
     if (!data) return
     // data : 새로 불러온 데이터 (예전 메시지)
     // currentData : 현재 데이터 (최근 메시지)
-    // TODO : 데이터 순서 논의해보기
-    const reversedData = data.reverse()
     setUpdatedData((currentData: IMessage[] | undefined) => {
-      if (!currentData) return reversedData
-      return [...reversedData, ...currentData]
+      if (!currentData) return data
+      return [...data, ...currentData]
     })
-    setIsEnd(reversedData[0].isEnd)
+    setIsEnd(data[0].isEnd)
     setPrevScrollHeight(scrollRef.current?.scrollHeight)
   }, [data])
 

--- a/src/app/my-page/message/[id]/panel/MessageForm.tsx
+++ b/src/app/my-page/message/[id]/panel/MessageForm.tsx
@@ -10,6 +10,7 @@ interface IMessageFormProps {
   targetId: number
   addNewMessage: (newMessage: IMessage) => void
   handleClose?: () => void // MOBILE_VIEW에서 모달을 닫기 위함
+  disabled?: boolean // PC_VIEW에서 채팅방이 삭제되었을 때 메시지 전송을 막기 위함
 }
 
 const MessageForm = ({
@@ -17,6 +18,7 @@ const MessageForm = ({
   targetId,
   addNewMessage,
   handleClose,
+  disabled,
 }: IMessageFormProps) => {
   const [content, setContent] = useState('')
   const axiosWithAuth = useAxiosWithAuth()
@@ -56,6 +58,7 @@ const MessageForm = ({
             placeholder="내용을 입력하세요"
             variant="outlined"
             onChange={(e) => setContent(e.target.value)}
+            disabled={disabled}
           />
           <CuButton
             variant="text"

--- a/src/app/my-page/message/[id]/panel/MessageForm.tsx
+++ b/src/app/my-page/message/[id]/panel/MessageForm.tsx
@@ -41,17 +41,21 @@ const MessageForm = ({
       )
       if (response.status === 201) {
         addNewMessage(response.data)
-        alert('메시지가 성공적으로 전송되었습니다.')
         setContent('')
       }
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 410) {
         // 채팅방이 삭제되었을 때
         updateTarget &&
-          updateTarget((prev) => ({
-            ...prev,
-            isDeleted: true,
-          }))
+          updateTarget((prev) => {
+            if (prev) {
+              return {
+                ...prev,
+                isDeleted: true,
+              }
+            }
+            return prev
+          })
       }
       alert('메시지 전송에 실패하였습니다.')
     } finally {

--- a/src/app/my-page/message/[id]/panel/MessageForm.tsx
+++ b/src/app/my-page/message/[id]/panel/MessageForm.tsx
@@ -79,6 +79,7 @@ const MessageForm = ({
             variant="text"
             action={() => messageSubmit()}
             message="전송"
+            disabled={disabled}
           />
         </Stack>
       ) : (

--- a/src/app/my-page/message/panel/MessageBar.tsx
+++ b/src/app/my-page/message/panel/MessageBar.tsx
@@ -35,6 +35,7 @@ interface IManageBarProps {
   handleSelectAll: () => void
   handleUnselectAll: () => void
   handleDelete: () => void
+  setIsManageMode: (isManageMode: boolean) => void
 }
 
 export const ManageBar = ({
@@ -42,9 +43,9 @@ export const ManageBar = ({
   handleSelectAll,
   handleUnselectAll,
   handleDelete,
+  setIsManageMode,
 }: IManageBarProps) => {
   return (
-    // 관리 모드 나가기 버튼?
     <Stack direction="row">
       {isSelectedAll ? (
         <CuButton
@@ -56,6 +57,11 @@ export const ManageBar = ({
         <CuButton variant="text" action={handleSelectAll} message="전체 선택" />
       )}
       <CuButton variant="text" action={handleDelete} message="삭제" />
+      <CuButton
+        variant="text"
+        action={() => setIsManageMode(false)}
+        message="리스트로 돌아가기"
+      />
     </Stack>
   )
 }

--- a/src/app/my-page/message/panel/MessageContainer.tsx
+++ b/src/app/my-page/message/panel/MessageContainer.tsx
@@ -90,6 +90,7 @@ const MessageContainer = ({
             }
             handleUnselectAll={unselectAll}
             handleDelete={handleDelete}
+            setIsManageMode={setIsManageMode}
           />
         ) : (
           <SearchBar

--- a/src/types/IMessage.ts
+++ b/src/types/IMessage.ts
@@ -27,6 +27,10 @@ export interface IMessageUser {
   userNickname: string
 }
 
+export interface IMessageTargetUser extends IMessageUser {
+  deleted: boolean
+}
+
 // 메시지 전송 타입
 
 export interface IMessageTarget {


### PR DESCRIPTION
close #302

### 작업내용

- (api 수정) 쪽지 target 객체에 deleted 값 추가. 상대가 삭제한 경우에는 메시지를 보낼 수 없게 입력창과 버튼을 비활성화했습니다. (테스트 완료 ✅)
- (api 수정) 쪽지 답장 시 410 에러가 오면 상대가 쪽지를 삭제한 경우이므로 입력창과 버튼을 비활성화했습니다. (테스트 전)
- (api 수정) 랜더링 순서에 맞게 쪽지 배열을 뒤집어서 보여주던 부분을 서버에서부터 뒤집어서 보여주도록 변경하여 배열을 뒤집는 로직을 삭제했습니다. (테스트 완료 ✅)
- 쪽지를 성공적으로 보낸 뒤의 alert 제거
- 쪽지 목록 관리 모드에서 관리모드를 빠져나가기 위한 버튼 추가