### PR TITLE
[C-MYPAGE] 쪽지 보내기 기능 누락 수정

### DIFF
--- a/src/app/my-page/message/[id]/panel/MessageForm.tsx
+++ b/src/app/my-page/message/[id]/panel/MessageForm.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useState } from 'react'
+import { Dispatch, FormEvent, SetStateAction, useState } from 'react'
 import { isAxiosError } from 'axios'
 import { Stack, TextField } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
@@ -23,10 +23,11 @@ const MessageForm = ({
   handleClose,
   disabled,
 }: IMessageFormProps) => {
-  const [content, setContent] = useState('')
   const axiosWithAuth = useAxiosWithAuth()
-  const messageSubmit = useCallback(async () => {
+  const [content, setContent] = useState<string>('')
+  const messageSubmit = async (e: FormEvent<HTMLFormElement>) => {
     try {
+      e.preventDefault()
       if (!content) {
         alert('내용을 입력하세요.')
         return
@@ -61,10 +62,10 @@ const MessageForm = ({
     } finally {
       handleClose && handleClose()
     }
-  }, [content])
+  }
 
   return (
-    <>
+    <form onSubmit={messageSubmit}>
       {view === 'PC_VIEW' ? (
         <Stack direction={'row'}>
           <TextField
@@ -77,7 +78,7 @@ const MessageForm = ({
           />
           <CuButton
             variant="text"
-            action={() => messageSubmit()}
+            type="submit"
             message="전송"
             disabled={disabled}
           />
@@ -99,15 +100,11 @@ const MessageForm = ({
               action={() => handleClose && handleClose()}
               message="취소"
             />
-            <CuButton
-              variant="contained"
-              action={() => messageSubmit()}
-              message="보내기"
-            />
+            <CuButton variant="contained" type="submit" message="보내기" />
           </Stack>
         </Stack>
       )}
-    </>
+    </form>
   )
 }
 


### PR DESCRIPTION
### 관련 버그리포트

close #389 

### 수정사항

PC 화면에서는 전송 버튼 뿐 아니라 엔터를 눌러서도 쪽지를 보낼 수 있었어야 했는데 그 부분이 누락되었었습니다...
submit 기능이 있어서 form 태그가 어울리는데 적용이 안되어있었어서 form 태그를 적용하면서 위의 문제도 같이 해결했습니다.