### PR TITLE
[C-MYPAGE] 마이페이지 Next Image 컴포넌트 mui box로 변경

### DIFF
--- a/src/app/my-page/profile/panel/ProfileBioEditor.tsx
+++ b/src/app/my-page/profile/panel/ProfileBioEditor.tsx
@@ -114,6 +114,7 @@ const ProfileBioEditor = ({
           dragMode: 'move',
           autoCropArea: 1,
           cropBoxResizable: false,
+          cropBoxMovable: false,
           modal: true,
           // ... other options
         })

--- a/src/app/my-page/profile/panel/ProfileCard.tsx
+++ b/src/app/my-page/profile/panel/ProfileCard.tsx
@@ -2,7 +2,6 @@
 import { Avatar, Box, Modal, Stack, Typography } from '@mui/material'
 import React, { useState } from 'react'
 import ProfileSection from './ProfileSection'
-import Image from 'next/image'
 
 // TODO css 다른 파일로 빼기
 
@@ -26,6 +25,7 @@ const ProfileImageModal = ({
       sx={{ border: 'none', outline: 'none' }}
     >
       <Box
+        component={'img'}
         sx={{
           width: '80%',
           position: 'absolute',
@@ -35,14 +35,9 @@ const ProfileImageModal = ({
           outline: 'none',
           transform: 'translate(-50%, -50%)',
         }}
-      >
-        <Image
-          width={500}
-          height={500}
-          alt="profile image"
-          src={profileImageUrl ? profileImageUrl : '/images/profile.jpeg'}
-        />
-      </Box>
+        alt="profile image"
+        src={profileImageUrl ? profileImageUrl : '/images/profile.jpeg'}
+      />
     </Modal>
   )
 }

--- a/src/app/my-page/profile/panel/ProfileCard.tsx
+++ b/src/app/my-page/profile/panel/ProfileCard.tsx
@@ -34,6 +34,8 @@ const ProfileImageModal = ({
           border: 'none',
           outline: 'none',
           transform: 'translate(-50%, -50%)',
+          maxWidth: '20rem',
+          maxHeight: '20rem',
         }}
         alt="profile image"
         src={profileImageUrl ? profileImageUrl : '/images/profile.jpeg'}

--- a/src/app/my-page/profile/panel/ProfileLinksSection.tsx
+++ b/src/app/my-page/profile/panel/ProfileLinksSection.tsx
@@ -5,6 +5,7 @@ import ProfileSection from './ProfileSection'
 import Link from 'next/link'
 
 const ProfileLink = (props: IUserProfileLink) => {
+  console.log(props.linkUrl)
   return (
     <Stack direction={'row'} spacing={0.5} alignItems={'center'}>
       <Box
@@ -16,7 +17,15 @@ const ProfileLink = (props: IUserProfileLink) => {
           height: '24px',
         }}
       />
-      <Link href={props.linkUrl} style={{ textDecorationColor: '#F6F6F6' }}>
+      <Link
+        href={
+          props.linkUrl.startsWith('http://') ||
+          props.linkUrl.startsWith('https://')
+            ? props.linkUrl
+            : `//${props.linkUrl}`
+        }
+        style={{ textDecorationColor: '#F6F6F6' }}
+      >
         <Typography variant={'Caption'} color={'text.strong'}>
           {props.linkName}
         </Typography>

--- a/src/app/panel/layout-panel/NavBar.tsx
+++ b/src/app/panel/layout-panel/NavBar.tsx
@@ -69,7 +69,7 @@ export const MobileNav = () => {
           icon={<ThumbUpAltOutlinedIcon />}
           label="히치하이킹"
           onClick={() => {
-            router.push('/')
+            router.push('/hitchhiking')
           }}
         />
         <BottomNavigationAction
@@ -148,7 +148,7 @@ export const PcNav = () => {
           <BottomNavigationAction
             label="히치하이킹"
             onClick={() => {
-              router.push('/')
+              router.push('/hitchhiking')
             }}
           />
 


### PR DESCRIPTION
#### 변경 사항
1. 히치하이킹에 대한 라우팅을 추가하였습니다.
2. 마이페이지의 next image 컴포넌트를 mui box로 변경하였습니다.
3. 마이페이지의 링크를 누르면 peer-test/www.mylink.com과 같이 사이트 도메인이 붙던 현상을 수정하였습니다.
    - 우선은 프로토콜이 없으면 '//'를 붙여 해당 링크가 도메인이 루트임을 알려주었으나 몇몇 sns 테스트 시 프로토콜을 명시하지 않으면 일단 'http://'를 붙여서 저장하고 있어 고민이 필요할 것 같습니다.
    - 참고 링크 : [Href without http(s) prefix](https://stackoverflow.com/questions/43803778/href-without-https-prefix)
4. 크롭 박스가 움직이던 현상을 수정하였습니다.