### PR TITLE
[DESIGN] 모집글 버튼 z-index 조정

### DIFF
--- a/src/app/panel/layout-panel/NavBar.tsx
+++ b/src/app/panel/layout-panel/NavBar.tsx
@@ -49,7 +49,7 @@ export const MobileNav = () => {
         left: 0,
         right: 0,
         overflow: 'hidden',
-        zIndex: 1300, // NOTE : 추후 모집글 버튼 z-index 조정 작업시에 함께 조정 필요함.
+        zIndex: 1300, // NOTE : 가능한 가장 높은 값으로 설정한 것이므로 이 값은 높이지 말아주세요. (낮추는건 괜찮습니다.)
       }}
     >
       <BottomNavigation
@@ -123,7 +123,7 @@ export const PcNav = () => {
         right: 0,
         top: 0,
         overflow: 'hidden',
-        zIndex: 1300, // NOTE : 추후 모집글 버튼 z-index 조정 작업시에 함께 조정 필요함.
+        zIndex: 1300, // NOTE : 가능한 가장 높은 값으로 설정한 것이므로 이 값은 높이지 말아주세요. (낮추는건 괜찮습니다.)
         backgroundColor: 'background.primary',
         paddingX: 3,
       }}

--- a/src/app/recruit/[id]/panel/ApplyButton.tsx
+++ b/src/app/recruit/[id]/panel/ApplyButton.tsx
@@ -34,7 +34,6 @@ const ApplyButton = ({
         disableElevation
         onClick={handleMenuClick}
         endIcon={<KeyboardArrowDown />}
-        // sx={{ zIndex: 1302 }} // TODO : zIndex 문제 해결되면 주석 삭제할 것.
       >
         지원하기
       </Button>

--- a/src/app/recruit/[id]/panel/LinkButton.style.ts
+++ b/src/app/recruit/[id]/panel/LinkButton.style.ts
@@ -1,0 +1,10 @@
+export const tooltip = {
+  padding: '1rem',
+}
+
+export const button = {
+  borderRadius: '50%',
+  width: 40,
+  height: 40,
+  backgroundColor: 'purple.tinted',
+}

--- a/src/app/recruit/[id]/panel/LinkButton.tsx
+++ b/src/app/recruit/[id]/panel/LinkButton.tsx
@@ -1,6 +1,19 @@
 import React from 'react'
-import { Button, Popover, Typography } from '@mui/material'
+import {
+  Button,
+  Tooltip,
+  TooltipProps,
+  styled,
+  tooltipClasses,
+} from '@mui/material'
 import InsertLinkOutlinedIcon from '@mui/icons-material/InsertLinkOutlined'
+import * as style from './LinkButton.style'
+
+const LinkTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(() => ({
+  [`& .${tooltipClasses.tooltip}`]: style.tooltip,
+}))
 
 const LinkButton = ({
   href,
@@ -9,56 +22,12 @@ const LinkButton = ({
   href: string
   variant: 'text' | 'outlined' | 'contained'
 }) => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-
-  const open = Boolean(anchorEl)
-  const id = open ? 'link-popover' : undefined
-
-  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const handlePopoverClose = () => {
-    setAnchorEl(null)
-  }
-
   return (
-    <div>
-      <Button
-        aria-describedby={id}
-        variant={variant}
-        size="large"
-        href={href}
-        onMouseEnter={handlePopoverOpen}
-        sx={{
-          // zIndex: 1304, // TODO : zIndex 문제 해결되면 주석 삭제할 것.
-          borderRadius: '50%',
-          width: 40,
-          height: 40,
-          backgroundColor: 'purple.tinted',
-        }}
-      >
+    <LinkTooltip placement="bottom-start" title={href}>
+      <Button variant={variant} size="large" href={href} sx={style.button}>
         <InsertLinkOutlinedIcon />
       </Button>
-      <Popover
-        id={id}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handlePopoverClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-        // sx={{ zIndex: 1303 }} // TODO : zIndex 문제 해결되면 주석 삭제할 것.
-        container={() => document.getElementById('modal-root')}
-      >
-        <Typography sx={{ padding: 2 }}>{href}</Typography>
-      </Popover>
-    </div>
+    </LinkTooltip>
   )
 }
 


### PR DESCRIPTION
### 작업 내용

수정 전

<img height="200" alt="Screen_Shot 2023-12-20 16 35 27" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/11b6dfb1-88f9-44d3-b081-0764b57d6948">

수정 후

<img height="200" alt="" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/425947ad-9764-492e-9177-d45b7b3102a4">

- 모집글 버튼의 z-index를 제거하기 위해서, 링크 버튼에 적용되어 있던 Popover를 Tooltip으로 수정했습니다.
  - Popover와 비슷한 Popper를 사용하려고 했었으나, 단순히 마우스 호버 시에 링크 정보만 보여주는 것이므로 Tooltip이 더 알맞겠다 생각했어요.
  - https://mui.com/material-ui/react-tooltip/
- 기존에도 padding 외에 특별히 디자인이 적용되어 있지 않았어서 이번에도 padding 외에는 디자인을 추가하지 않았습니다.
- 헤더와 네비게이션 바에 적용한 z-index를 좀 낮춰주려고 했었는데, 어떤 값으로 설정해야 할지 잘 모르겠어서 그대로 두고 주석만 수정해두었습니다.

### 관련 이슈

- close #418