### PR TITLE
[PUBLIC] CuToast 디자인 변경 및 message prop 타입 변경

### DIFF
--- a/src/app/my-page/homepage-setting/page.tsx
+++ b/src/app/my-page/homepage-setting/page.tsx
@@ -11,7 +11,7 @@ import useMedia from '@/hook/useMedia'
 
 interface IToast {
   severity: AlertColor | undefined
-  message: string
+  message: React.ReactNode
 }
 
 const HomepageSetting = () => {

--- a/src/app/my-page/homepage-setting/panel/KeywordSetting.tsx
+++ b/src/app/my-page/homepage-setting/panel/KeywordSetting.tsx
@@ -25,7 +25,7 @@ interface IChip {
 
 interface IToastProps {
   severity: AlertColor | undefined
-  message: string
+  message: React.ReactNode
 }
 
 const KeywordAddingField = ({
@@ -66,7 +66,11 @@ const KeywordAddingField = ({
       .then(() => {
         setToastMessage({
           severity: 'success',
-          message: `'${trimmed}'를 알림 키워드 목록에 추가하였습니다.`,
+          message: (
+            <>
+              <b>{trimmed}</b>(이)가 키워드로 등록되었습니다.
+            </>
+          ),
         })
         mutate()
       })
@@ -79,7 +83,11 @@ const KeywordAddingField = ({
         } else {
           setToastMessage({
             severity: 'error',
-            message: `'${trimmed}'를 알림 키워드 목록에 추가하지 못했습니다.`,
+            message: (
+              <>
+                <b>{trimmed}</b>(을)를 알림 키워드 목록에 추가하지 못했습니다.
+              </>
+            ),
           })
         }
       })

--- a/src/components/CuToast.tsx
+++ b/src/components/CuToast.tsx
@@ -14,6 +14,8 @@ import React from 'react'
 import { CloseIcon } from '@/icons'
 import useMedia from '@/hook/useMedia'
 import * as style from './CuToast.style'
+import { useDarkMode } from '@/states/useDarkMode'
+import { EDisplayMode } from '@/types/DisplayTypes'
 
 const hexToDecimalArray = (hex: string | undefined) => {
   if (!hex) {
@@ -126,6 +128,7 @@ const CuToast = ({
   subButton?: React.ReactNode
 }) => {
   const { isPc } = useMedia()
+  const { darkMode } = useDarkMode()
   return (
     <Snackbar
       open={open}
@@ -157,7 +160,10 @@ const CuToast = ({
               <CloseIcon
                 sx={{
                   ...style.closeIconStyle,
-                  color: 'text.assistive',
+                  color:
+                    darkMode === EDisplayMode.dark
+                      ? 'text.alternative'
+                      : 'text.assistive',
                 }}
               />
             </IconButton>

--- a/src/components/CuToast.tsx
+++ b/src/components/CuToast.tsx
@@ -107,6 +107,18 @@ function TransitionLeft(props: SlideProps) {
   return <Slide {...props} direction="right" />
 }
 
+/**
+ *
+ * @param open      : toast를 띄울지 말지 결정하는 boolean
+ * @param onClose   : toast를 닫는 함수
+ * @param severity  : toast의 색깔을 결정하는 string
+ * @param message   : toast에 띄울 메시지
+ * @param subButton : toast에 띄울 버튼
+ * @param sx        : toast의 style
+ * @param autoHideDuration : toast가 얼마나 띄워질지 결정하는 number
+ * @returns         : toast
+ */
+
 const CuToast = ({
   open,
   autoHideDuration = 60000,
@@ -124,7 +136,7 @@ const CuToast = ({
   severity?: AlertColor | undefined
   sx?: SxProps
   children?: React.ReactNode
-  message?: string
+  message?: React.ReactNode
   subButton?: React.ReactNode
 }) => {
   const { isPc } = useMedia()
@@ -170,7 +182,6 @@ const CuToast = ({
           </Stack>
         }
       >
-        {/* 기존에는 타이포그래피를 넣게 하였으나 앞으로는 message prop에 넣는 것으로 처리해야 합니다.*/}
         <Typography variant="Body2">{message}</Typography>
       </Alert>
     </Snackbar>


### PR DESCRIPTION
### 변경 사항
1. 다크모드에서 x가 잘 보이지 않는다는 지적이 있어 색을 변경하였습니다. 보고 더 밝은 색으로 바꿔야 할 것 같으면 말씀해주세요.
2. message prop의 타입을 React.Node로 변경하였습니다. 이는 중간에 `<b>` 태그 등의 인라인 태그를 넣기 위함입니다.

<img width="848" alt="스크린샷 2024-01-09 오전 1 05 46" src="https://github.com/peer-42seoul/Peer-Frontend/assets/91731260/1e3b0e31-2c4c-401f-9546-5141236e7e0a">
