### PR TITLE
[S-SC] 쇼케이스 리다이렉션 페이지 구현

### DIFF
--- a/src/app/showcase/[id]/panel/ShowcaseViewer.tsx
+++ b/src/app/showcase/[id]/panel/ShowcaseViewer.tsx
@@ -14,14 +14,16 @@ interface IShowcaseViewerProps {
 const ShowcaseViewer = ({ data }: IShowcaseViewerProps) => {
   return (
     <Stack direction={'column'} spacing={'2.5rem'} sx={{ width: '26rem' }}>
+      ## TODO hoslim이 만든 컴포넌트로교체하기
       {/* <InteractiveButtonGroup /> */}
       <Box component="img" src={data?.image} alt="쇼케이스 이미지" />
-      <TeamName teamName={data?.title} />
+      <TeamName teamName={data?.name} />
       <StartEndDateViewer start={data?.start} end={data?.end} />
       <SkillInput skills={data?.skills} />
       <TeamMembers members={data?.member} />
       <LinksViewer links={data?.links} />
       <ToastViewer initialValue={data?.content} height="30rem" />
+      ## TODO 댓글 추가하기
       {/* <CommentPage /> */}
     </Stack>
   )

--- a/src/app/showcase/panel/ShowcaseEditor.tsx
+++ b/src/app/showcase/panel/ShowcaseEditor.tsx
@@ -76,6 +76,7 @@ const ShowcaseEditor = ({
         router.push(`/showcase/${response.data.get('id')}`)
       }
     } catch (error: any) {
+      closeModal()
       if (error.response) {
         switch (error.response.status) {
           case 400:
@@ -88,6 +89,10 @@ const ShowcaseEditor = ({
             break
           case 404:
             setErrorMessages('페이지를 찾을 수 없습니다. (NOT_FOUND)')
+            openToast()
+            break
+          case 409:
+            setErrorMessages('이미 쇼케이스가 존재합니다.')
             openToast()
             break
           default:

--- a/src/app/showcase/panel/ShowcaseEditor.tsx
+++ b/src/app/showcase/panel/ShowcaseEditor.tsx
@@ -112,10 +112,10 @@ const ShowcaseEditor = ({
           setImage={setImage}
           setPreviewImage={setPreviewImage}
         />
-        <TeamName teamName={data.title} />
+        <TeamName teamName={data.name} />
         <SkillInput skills={data.skills} />
         <StartEndDateViewer start={data.start} end={data.end} />
-        <TeamMembers members={data?.member} />
+        <TeamMembers members={data?.memberList} />
         <LinkForm
           links={links}
           addLink={addLink}

--- a/src/app/showcase/panel/common/LinksViewer.tsx
+++ b/src/app/showcase/panel/common/LinksViewer.tsx
@@ -11,6 +11,10 @@ interface IlinksProps {
 const LinksViewer = ({ links }: IlinksProps) => {
   return (
     <Stack>
+      <LabelWithIcon
+        svgIcon={<TagIcon sx={Style.IconStyle} />}
+        message="링크모음"
+      />
       {links?.map((link: any) => {
         return (
           <Stack
@@ -19,10 +23,6 @@ const LinksViewer = ({ links }: IlinksProps) => {
             width={'26rem'}
             key={link.id}
           >
-            <LabelWithIcon
-              svgIcon={<TagIcon sx={Style.IconStyle} />}
-              message="링크모음"
-            />
             <Stack
               spacing={0.75}
               py={1}

--- a/src/app/teams/[id]/showcase/page.tsx
+++ b/src/app/teams/[id]/showcase/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { Stack, Typography } from '@mui/material'
+import React from 'react'
+import CreateShowcasePage from './panel/CreateShowcasePage'
+
+const ShowcaseGenerationPage = () => {
+  // TODO: 백엔드 연동해서 상태값 가져오기 필요한거 : 작성 상태에 따라서 다름. isShowcaseComplete은 기본.
+  // 작성이 된 상태라면 쇼케이스 id값도 가져와야함 (바로 리다이렉션 해주기 위해서).
+  const isShowcaseComplete = false
+  return (
+    <Stack
+      display={'flex'}
+      width={'56.75rem'}
+      padding={'2rem 0rem'}
+      flexDirection={'column'}
+      gap={'4rem'}
+    >
+      <Typography color={'noraml'}>쇼케이스</Typography>
+      <Stack
+        display={'flex'}
+        flexDirection={'row'}
+        padding={'1.5rem'}
+        justifyContent={'center'}
+        alignItems={'center'}
+        gap={'1.5rem'}
+        alignSelf={'stretch'}
+        borderRadius={'1.5rem'}
+        sx={{ backgroundColor: 'background.secondary' }}
+      >
+        <CreateShowcasePage isShowcaseComplete={isShowcaseComplete} />
+      </Stack>
+    </Stack>
+  )
+}
+
+export default ShowcaseGenerationPage

--- a/src/app/teams/[id]/showcase/panel/ContentSection.tsx
+++ b/src/app/teams/[id]/showcase/panel/ContentSection.tsx
@@ -1,0 +1,26 @@
+import { Typography } from '@mui/material'
+import React from 'react'
+
+const ContentSection = ({
+  isShowcaseComplete,
+}: {
+  isShowcaseComplete: boolean
+}) => {
+  const notExistenceMessage =
+    '쇼케이스는 피어로그에 담에내지 못한 비하인드 스토리를 담는 기술 블로그입니다. PC버전에서 쇼케이스 글 작성하기 버튼을 클릭해 프로젝트를 뽐낼 수 있는 쇼케이스 글을 작성해보세요.'
+  const existenceMessage =
+    '쇼케이스는 피어로그에 담에내지 못한 비하인드 스토리를 담는 기술 블로그입니다. 쇼케이스 글을 완성했다면, 공개버튼을 클릭해 멋진 프로젝트를 자랑해보세요.'
+
+  return (
+    <Typography
+      color={'noraml'}
+      lineHeight={'1rem'}
+      fontSize={'0.75rem'}
+      fontWeight={'400'}
+    >
+      {isShowcaseComplete ? notExistenceMessage : existenceMessage}
+    </Typography>
+  )
+}
+
+export default ContentSection

--- a/src/app/teams/[id]/showcase/panel/CreateShowcasePage.tsx
+++ b/src/app/teams/[id]/showcase/panel/CreateShowcasePage.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import ContentSection from './ContentSection'
+import IntersectionSection from './IntersectionSection'
+
+const CreateShowcasePage = ({
+  isShowcaseComplete,
+}: {
+  isShowcaseComplete: boolean
+}) => {
+  return (
+    <>
+      <ContentSection isShowcaseComplete={isShowcaseComplete} />
+      <IntersectionSection isShowcaseComplete={isShowcaseComplete} />
+    </>
+  )
+}
+
+export default CreateShowcasePage

--- a/src/app/teams/[id]/showcase/panel/IntersectionSection.tsx
+++ b/src/app/teams/[id]/showcase/panel/IntersectionSection.tsx
@@ -1,7 +1,7 @@
 import CuButton from '@/components/CuButton'
 import CuTypeToggle from '@/components/CuTypeToggle'
 import { EditIcon } from '@/icons'
-import { FormControlLabel, Stack } from '@mui/material'
+import { FormControlLabel } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import React, { useEffect, useState } from 'react'
 

--- a/src/app/teams/[id]/showcase/panel/IntersectionSection.tsx
+++ b/src/app/teams/[id]/showcase/panel/IntersectionSection.tsx
@@ -1,0 +1,73 @@
+import CuButton from '@/components/CuButton'
+import CuTypeToggle from '@/components/CuTypeToggle'
+import { EditIcon } from '@/icons'
+import { FormControlLabel, Stack } from '@mui/material'
+import { useRouter } from 'next/navigation'
+import React, { useEffect, useState } from 'react'
+
+const IntersectionSection = ({
+  isShowcaseComplete,
+}: {
+  isShowcaseComplete: boolean
+}) => {
+  // TODO: 1. id백엔드에서 받아오기
+  // TODO: 2. 공개여부 백엔드 연동
+
+  const id = 3
+  const router = useRouter()
+  const [isShow, setIsShow] = useState(false)
+
+  useEffect(() => {
+    console.log(`공개여부가 변경되었습니다. ${isShow}`)
+  }, [isShow])
+
+  const handleChange = () => {
+    setIsShow(!isShow)
+  }
+  return (
+    <>
+      {isShowcaseComplete ? (
+        <>
+          <CuButton
+            message="쇼케이스 보기"
+            style={{
+              textAlign: 'center',
+              fontWeight: '600',
+              fontSize: '0.75rem',
+            }}
+            action={() => {
+              router.push(`/showcase/${id}`)
+            }}
+          />
+          {/* <CuButton
+            message="쇼케이스 공개여부"
+            style={{
+              textAlign: 'center',
+              fontWeight: '600',
+              fontSize: '0.75rem',
+            }}
+          /> */}
+          <FormControlLabel
+            control={<CuTypeToggle checked={isShow} onChange={handleChange} />}
+            label={isShow ? 'ON' : 'OFF'}
+          />
+        </>
+      ) : (
+        <CuButton
+          style={{
+            textAlign: 'center',
+            fontWeight: '600',
+            fontSize: '0.75rem',
+          }}
+          startIcon={<EditIcon width={'1.25rem'} height={'1.25rem'} />}
+          message="쇼케이스 작성하기"
+          action={() => {
+            router.push('/showcase/write')
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default IntersectionSection

--- a/src/types/IShowcaseEdit.ts
+++ b/src/types/IShowcaseEdit.ts
@@ -21,24 +21,19 @@ export interface ISkill {
   color: string
 }
 
+// /write 디렉토리 interface
 export interface IShowcaseEditorFields {
-  title: string
+  name: string
   skills: ISkill[]
   start: string
   end: string
-  member: IMember[]
+  memberList: IMember[]
   links: IUserProfileLink[]
 }
 
-export interface IShowcaseEditorProps {
-  data: IShowcaseEditorFields // IShowcase 타입을 import 해야 합니다.
-  teamId: number
-  requestMethodType: 'post' | 'put'
-  router: any | undefined
-}
-
+// /[id] 디렉토리 interface
 export interface IShowcaseViewerFields {
-  title: string
+  name: string
   skills: ISkill[]
   start: string
   end: string
@@ -47,6 +42,13 @@ export interface IShowcaseViewerFields {
   content: string
   image: string
 }
+export interface IShowcaseEditorProps {
+  data: IShowcaseEditorFields // IShowcase 타입을 import 해야 합니다.
+  teamId: number
+  requestMethodType: 'post' | 'put'
+  router: any | undefined
+}
+
 export interface ILinkInformation {
   id: number
   name: string


### PR DESCRIPTION

### 구현 사항 
- 팀페이지에서 쇼케이스 탭 부분 레이아웃 구현

<img width="751" alt="Screenshot 2024-01-21 at 6 34 41 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/62472550/5d5f9f40-3cd9-4ab5-82af-ce5895dc4795">


### 남은 사항
- 스타일 적용
- 백엔드 api 연동