### PR TITLE
[J-TB] 모집글 작성/수정 QA 이미지 4mb 용량 업로드 제한 적용

### DIFF
--- a/src/components/ImageUploadButton.tsx
+++ b/src/components/ImageUploadButton.tsx
@@ -47,6 +47,13 @@ const ImageUploadButton = ({
 }) => {
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files && e.target.files[0]
+
+    // 파일이 선택되었고, 그 크기가 4MB를 초과하면 경고 메시지를 보여주고 함수를 빠져나갑니다.
+    if (file && file.size > 4 * 1024 * 1024) {
+      alert('파일 크기가 4MB를 초과하였습니다.')
+      return
+    }
+
     if (e.target.files && e.target.files?.length && e.target.files[0]) {
       const reader = new FileReader()
       setImage([e.target.files[0]])


### PR DESCRIPTION
이미지 업로드시 이미지 4mb 용량 업로드 제한 적용이 완료되었습니다.
아래와 같이 alert로 막아버림.

해당 사진
<img width="743" alt="Screenshot 2024-01-23 at 1 40 17 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/87654307/4070ae16-d4f6-465d-9680-7c7e2ebf7384">
