### PR TITLE
[S-SC] 쇼케이스 수정폼 에러 수정

### DIFF
--- a/src/app/showcase/panel/ShowcaseEditor.tsx
+++ b/src/app/showcase/panel/ShowcaseEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Button, Stack } from '@mui/material'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { IShowcaseEditorFields } from '@/types/IShowcaseEdit'
 import ImageInput from '../panel/common/ImageInput'
 import TeamName from '../panel/common/TeamName'
@@ -35,6 +35,7 @@ const ShowcaseEditor = ({
   requestMethodType,
 }: IShowcaseEditorProps) => {
   const axiosWithAuth = useAxiosWithAuth()
+  const [image, setImage] = useState<File[]>([])
   const [previewImage, setPreviewImage] = useState<string>(
     data.image ?? '/images/defaultImage.png',
   )
@@ -43,8 +44,14 @@ const ShowcaseEditor = ({
   const { isOpen: alertOpen, closeModal, openModal } = useModal()
   const { links, addLink, isValid, setIsValid, changeLinkName, changeUrl } =
     useLinks(data.links ? data.links : [])
-  const { content } = useShowCaseState()
+  const { content, setContent } = useShowCaseState()
   const router = useRouter()
+
+  useEffect(() => {
+    if (requestMethodType === 'put') {
+      setContent(data?.content)
+    }
+  }, [requestMethodType, data?.content])
 
   const submitHandler = async () => {
     const linksWithoutId = links.map(({ ...rest }) => rest)
@@ -53,7 +60,7 @@ const ShowcaseEditor = ({
     }
     try {
       if (requestMethodType === 'post') {
-        const response = await axiosWithAuth.post(
+        await axiosWithAuth.post(
           `${process.env.NEXT_PUBLIC_API_URL}/api/v1/showcase/write`,
           {
             image: previewImage.split(',')[1],
@@ -62,19 +69,17 @@ const ShowcaseEditor = ({
             links: linksWithoutId,
           },
         )
-        console.log(response)
-        router.push(`/showcase/$${teamId}}`) // next 13에서 redirect 하는 법
+        router.push(`/showcase/${teamId}`)
       } else if (requestMethodType === 'put') {
-        const response = await axiosWithAuth.put(
+        await axiosWithAuth.put(
           `${process.env.NEXT_PUBLIC_API_URL}/api/v1/showcase/edit/${teamId}`,
           {
-            image: previewImage.split(',')[1],
+            image: image.length ? previewImage.split(',')[1] : null,
             content: content,
             links: linksWithoutId,
           },
         )
-        console.log(response)
-        router.push(`/showcase/$${teamId}}`) // next 13에서 redirect 하는 법
+        router.push(`/showcase/${teamId}`)
       }
     } catch (error: any) {
       closeModal()
@@ -114,8 +119,8 @@ const ShowcaseEditor = ({
       <Stack direction={'column'} spacing={'2.5rem'} sx={{ width: '26rem' }}>
         <ImageInput
           previewImage={previewImage}
-          // image={image}
-          // setImage={setImage}
+          image={image}
+          setImage={setImage}
           setPreviewImage={setPreviewImage}
         />
         <TeamName teamName={data.name} />

--- a/src/app/showcase/panel/common/FormUIEditor.tsx
+++ b/src/app/showcase/panel/common/FormUIEditor.tsx
@@ -24,7 +24,6 @@ const FormUIEditor = ({
   const { setContent } = useShowCaseState()
   const themed = useTheme()
   const editorRef = useRef<HTMLDivElement>(null)
-  const CONTENT_MAX = 100000
   const toggleDark = () => {
     const editorEl = editorRef.current?.getElementsByClassName(
       'toastui-editor-defaultUI',
@@ -65,10 +64,10 @@ const FormUIEditor = ({
       editor.current.on('change', () => {
         if (editor.current) {
           const content = editor.current?.getMarkdown()
-          if (content.length > CONTENT_MAX) {
-            alert(`최대 ${CONTENT_MAX}자까지 입력 가능합니다.`)
-            return
-          }
+          // if (content.length > CONTENT_MAX) {
+          //   alert(`최대 ${CONTENT_MAX}자까지 입력 가능합니다.`)
+          //   return
+          // }
           setContent(content)
         }
       })

--- a/src/app/showcase/panel/common/ImageInput.tsx
+++ b/src/app/showcase/panel/common/ImageInput.tsx
@@ -10,9 +10,13 @@ import * as Style from './SkillInput.style'
 const ImageInput = ({
   previewImage,
   setPreviewImage, // setImage,
-}: {
+  setImage,
+} // image,
+: {
   previewImage: string
   setPreviewImage: (image: string) => void
+  image: File[]
+  setImage: (image: File[]) => void
 }) => {
   return (
     <Stack direction={'column'} spacing={'0.5rem'} alignItems={'flex-start'}>
@@ -20,7 +24,12 @@ const ImageInput = ({
         svgIcon={<ImageIcon sx={Style.IconStyle} />}
         message={'쇼케이스 대표 이미지'}
       />
-      <ImageUploadButton setPreviewImage={setPreviewImage}>
+      <ImageUploadButton
+        setImage={(image: File[]) => {
+          setImage(image)
+        }}
+        setPreviewImage={setPreviewImage}
+      >
         {previewImage ? (
           <Box
             component={'img'}

--- a/src/states/useShowCaseState.tsx
+++ b/src/states/useShowCaseState.tsx
@@ -1,13 +1,13 @@
 import { create } from 'zustand'
 
 interface IShowCaseState {
-  content: string
-  setContent: (newContent: string) => void
+  content: string | undefined
+  setContent: (newContent: string | undefined) => void
 }
 
 const useShowCaseState = create<IShowCaseState>((set) => ({
   content: '',
-  setContent: (newContent: string) => set({ content: newContent }),
+  setContent: (newContent: string | undefined) => set({ content: newContent }),
 }))
 
 export default useShowCaseState


### PR DESCRIPTION
## 수정사항 


1. ShocaseEditor.tsx 에서 컨텐츠에 새로 수정된 사항이 없으면 content 데이터를 null 로 입력하여 초기화 하던 현상을 수정했습니다.
```js
// 추가된 코드
// 기존에는 setContent에 아무런 값을 불러오지 않아서 수정하면 컨텐츠가 사라지는 현상이 있었습니다.
 useEffect(() => {
    if (requestMethodType === 'put') {
      setContent(data?.content)
    }
  }, [requestMethodType, data?.content])
```


2. put 요청 시 대표 이미지가 수정되지 않으면 image가 put 되지 않던 사항을 수정하였습니다.
```js
// 추가된 코드
// image 객체에 새로 수정된 값이 없을 경우엔 이미지를 null로 보냅니다.
   await axiosWithAuth.put(
          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/showcase/edit/${teamId}`,
          {
            image: image.length ? previewImage.split(',')[1] : null,
            content: content,
            links: linksWithoutId,
          },
        )

```

