### PR TITLE
[Public] 튜토리얼 컴포넌트 추가

### DIFF
--- a/src/app/panel/MainPage.tsx
+++ b/src/app/panel/MainPage.tsx
@@ -32,6 +32,8 @@ import MainBanner from '@/app/panel/main-page/MainBanner'
 import io from 'socket.io-client'
 import { getCookie } from 'cookies-next'
 import useSocket from '@/states/useSocket'
+import Tutorial from '@/components/Tutorial'
+import { MainPageTutorial } from '@/components/tutorialContent/MainPageTutorial'
 
 export interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[]
@@ -272,7 +274,13 @@ const MainPage = ({ initData }: { initData: IPagination<IPost[]> }) => {
           <Stack direction={'row'} border="1px solid black" spacing={4}>
             <Stack flex={1} gap={'0.5rem'}>
               <MainBanner />
-              <SelectType type={type} setType={handleType} />
+              <Stack direction={'row'} justifyContent={'space-between'}>
+                <SelectType type={type} setType={handleType} />
+                <Tutorial
+                  title={'프로젝트 검색'}
+                  content={<MainPageTutorial />}
+                />
+              </Stack>
               <Grid container bgcolor={'Background.primary'}>
                 <SearchOption
                   openOption={openOption}

--- a/src/components/Tutorial.style.ts
+++ b/src/components/Tutorial.style.ts
@@ -1,7 +1,7 @@
 import { Theme } from '@mui/material'
 
 const modal = {
-  position: 'absolute' as 'absolute',
+  position: 'absolute',
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',

--- a/src/components/Tutorial.style.ts
+++ b/src/components/Tutorial.style.ts
@@ -1,0 +1,24 @@
+import { Theme } from '@mui/material'
+
+const modal = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  borderRadius: '2rem',
+  maxHeight: '70vh',
+  backgroundColor: (theme: Theme) => theme.palette.background.primary,
+}
+
+export const mobileModal = {
+  ...modal,
+  width: '85vw',
+  minWidth: '20.5rem',
+  padding: '1.25rem 1.25rem 1.5rem 1.25rem',
+}
+
+export const pcModal = {
+  ...modal,
+  minWidth: '30rem',
+  padding: '1.5rem 2rem',
+}

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -24,9 +24,9 @@ const Tutorial = ({ title, content }: ITutorialProps) => {
           sx={isPc ? style.pcWrapper : style.mobileWrapper}
         >
           <Typography
-            sx={{ padding: '0.375rem 0' }}
             variant={isPc ? 'Title2Emphasis' : 'Body1Emphasis'}
             color="text.normal"
+            lineHeight={'2.5rem'}
           >
             {title}
           </Typography>

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, useState } from 'react'
-import { IconButton, Modal, Stack, Typography } from '@mui/material'
+import { Box, IconButton, Modal, Stack, Typography } from '@mui/material'
 import { Help } from '@mui/icons-material'
 import useMedia from '@/hook/useMedia'
 import { CloseIcon } from '@/icons'
-import * as style from './CuModal.style'
+import * as style from './Tutorial.style'
 
 interface ITutorialProps {
   title?: string
@@ -21,7 +21,7 @@ const Tutorial = ({ title, content }: ITutorialProps) => {
       <Modal open={open} onClose={() => setOpen(false)} keepMounted>
         <Stack
           alignItems={'center'}
-          sx={isPc ? style.pcWrapper : style.mobileWrapper}
+          sx={isPc ? style.pcModal : style.mobileModal}
         >
           <Typography
             variant={isPc ? 'Title2Emphasis' : 'Body1Emphasis'}
@@ -46,7 +46,7 @@ const Tutorial = ({ title, content }: ITutorialProps) => {
               sx={{ color: 'text.assistive' }}
             />
           </IconButton>
-          <>{content}</>
+          <Box sx={{ overflowY: 'scroll' }}>{content}</Box>
         </Stack>
       </Modal>
     </>

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,0 +1,56 @@
+import { ReactNode, useState } from 'react'
+import { IconButton, Modal, Stack, Typography } from '@mui/material'
+import { Help } from '@mui/icons-material'
+import useMedia from '@/hook/useMedia'
+import { CloseIcon } from '@/icons'
+import * as style from './CuModal.style'
+
+interface ITutorialProps {
+  title?: string
+  content: ReactNode
+}
+
+const Tutorial = ({ title, content }: ITutorialProps) => {
+  const [open, setOpen] = useState(false)
+  const { isPc } = useMedia()
+  return (
+    <>
+      <IconButton onClick={() => setOpen(true)}>
+        <Help sx={{ color: 'purple.strong' }} />
+      </IconButton>
+      <Modal open={open} onClose={() => setOpen(false)} keepMounted>
+        <Stack
+          alignItems={'center'}
+          sx={isPc ? style.pcWrapper : style.mobileWrapper}
+        >
+          <Typography
+            sx={{ padding: '0.375rem 0' }}
+            variant={isPc ? 'Title2Emphasis' : 'Body1Emphasis'}
+            color="text.normal"
+          >
+            {title}
+          </Typography>
+          <IconButton
+            sx={{
+              width: '2.5rem',
+              height: '2.5rem',
+              position: 'absolute',
+              top: ['1.5rem', '1.5rem'],
+              right: ['1.5rem', '2rem'],
+            }}
+            onClick={() => setOpen(false)}
+          >
+            <CloseIcon
+              width={'1.25rem'}
+              height={'1.25rem'}
+              sx={{ color: 'text.assistive' }}
+            />
+          </IconButton>
+          <>{content}</>
+        </Stack>
+      </Modal>
+    </>
+  )
+}
+
+export default Tutorial

--- a/src/components/tutorialContent/MainPageTutorial.tsx
+++ b/src/components/tutorialContent/MainPageTutorial.tsx
@@ -1,0 +1,29 @@
+import {
+  Content,
+  SubTitle,
+  TitleContianer,
+  TutorialContainer,
+} from './TutorialComponent'
+
+export const MainPageTutorial = () => {
+  return (
+    <TutorialContainer>
+      <TitleContianer>
+        <SubTitle text={'스터디와 프로젝트를 찾아요.'} />
+        <Content
+          text={
+            '스터디 버튼을 눌러 참여할 수 있는 스터디를, 프로젝트 버튼을 눌러 참여할 수 있는 프로젝트를 확인할 수 있습니다.'
+          }
+        />
+      </TitleContianer>
+      <TitleContianer>
+        <SubTitle text={'필터를 이용해 맞춤 프로젝트를 찾아요.'} />
+        <Content
+          text={
+            '사용하는 기술스택부터 목표 기간, 활동 방식과 지역을 선택해서 좀 더 맞는 프로젝트와 스터디를 찾아보세요!'
+          }
+        />
+      </TitleContianer>
+    </TutorialContainer>
+  )
+}

--- a/src/components/tutorialContent/TutorialComponent.tsx
+++ b/src/components/tutorialContent/TutorialComponent.tsx
@@ -1,0 +1,48 @@
+import { Stack, Typography } from '@mui/material'
+import useMedia from '@/hook/useMedia'
+
+interface childrenProps {
+  children: React.ReactNode
+}
+
+interface textProps {
+  text: string
+}
+
+export const TutorialContainer = ({ children }: childrenProps) => {
+  return (
+    <Stack
+      width={'100%'}
+      height={'100%'}
+      alignItems={'center'}
+      spacing={'0.5rem'}
+    >
+      {children}
+    </Stack>
+  )
+}
+
+export const TitleContianer = ({ children }: childrenProps) => {
+  return <Stack width={'100%'}>{children}</Stack>
+}
+
+export const SubTitle = ({ text }: textProps) => {
+  const { isPc } = useMedia()
+  return (
+    <Typography
+      variant={isPc ? 'Title3Emphasis' : 'Body2Emphasis'}
+      color={'text.normal'}
+    >
+      {text}
+    </Typography>
+  )
+}
+
+export const Content = ({ text }: textProps) => {
+  const { isPc } = useMedia()
+  return (
+    <Typography variant={isPc ? 'Body1' : 'Caption'} color={'text.normal'}>
+      {text}
+    </Typography>
+  )
+}

--- a/src/components/tutorialContent/TutorialComponent.tsx
+++ b/src/components/tutorialContent/TutorialComponent.tsx
@@ -9,6 +9,7 @@ interface textProps {
   text: string
 }
 
+// 튜토리얼 컨텐츠의 최상위 컨테이너
 export const TutorialContainer = ({ children }: childrenProps) => {
   return (
     <Stack
@@ -22,10 +23,12 @@ export const TutorialContainer = ({ children }: childrenProps) => {
   )
 }
 
+// 제목 - 내용을 감싸는 컨테이너
 export const TitleContianer = ({ children }: childrenProps) => {
   return <Stack width={'100%'}>{children}</Stack>
 }
 
+// 제목 typography
 export const SubTitle = ({ text }: textProps) => {
   const { isPc } = useMedia()
   return (
@@ -38,6 +41,7 @@ export const SubTitle = ({ text }: textProps) => {
   )
 }
 
+// 내용 typography
 export const Content = ({ text }: textProps) => {
   const { isPc } = useMedia()
   return (

--- a/src/components/tutorialContent/TutorialComponent.tsx
+++ b/src/components/tutorialContent/TutorialComponent.tsx
@@ -1,16 +1,16 @@
 import { Stack, Typography } from '@mui/material'
 import useMedia from '@/hook/useMedia'
 
-interface childrenProps {
+interface IchildProps {
   children: React.ReactNode
 }
 
-interface textProps {
+interface ItextProps {
   text: string
 }
 
 // 튜토리얼 컨텐츠의 최상위 컨테이너
-export const TutorialContainer = ({ children }: childrenProps) => {
+export const TutorialContainer = ({ children }: IchildProps) => {
   return (
     <Stack
       width={'100%'}
@@ -24,12 +24,12 @@ export const TutorialContainer = ({ children }: childrenProps) => {
 }
 
 // 제목 - 내용을 감싸는 컨테이너
-export const TitleContianer = ({ children }: childrenProps) => {
+export const TitleContianer = ({ children }: IchildProps) => {
   return <Stack width={'100%'}>{children}</Stack>
 }
 
 // 제목 typography
-export const SubTitle = ({ text }: textProps) => {
+export const SubTitle = ({ text }: ItextProps) => {
   const { isPc } = useMedia()
   return (
     <Typography
@@ -42,7 +42,7 @@ export const SubTitle = ({ text }: textProps) => {
 }
 
 // 내용 typography
-export const Content = ({ text }: textProps) => {
+export const Content = ({ text }: ItextProps) => {
   const { isPc } = useMedia()
   return (
     <Typography variant={isPc ? 'Body1' : 'Caption'} color={'text.normal'}>


### PR DESCRIPTION
### 작업 내용

튜토리얼을 띄울 수 있는 버튼과 모달을 추가했습니다.
Tutorial 컴포넌트에 튜토리얼 컨텐츠를 Props로 전달할 수 있게 했고
(튜토리얼 컨텐츠는 페이지에 두는 것 보다 따로 폴더에 모아두는게 좋을 것 같아요 `@/components/tutorialContent/MainPageTutorial`)
일괄적인 디자인을 넣기 편하게 Tutorial Component 들을 추가했습니다.
디자인 적용 확인을 위해서 임시로 메인 페이지 튜토리얼을 추가했습니다.

<img width="40%" alt="     " src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/f3474cc0-9d87-4dea-9e28-bec636cc5913">
<img width="40%" alt="Screen_Shot 2024-02-01 13 42 17" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0430723b-7d27-49b7-9b32-abbf9c2eeae0">
