### PR TITLE
[PUBLIC] 토스트 에디터 뷰어 폰트 컬러 변경 

### DIFF
--- a/src/components/ToastUIViewer.tsx
+++ b/src/components/ToastUIViewer.tsx
@@ -34,9 +34,16 @@ const ToastViewer = ({
   }, [initialValue, viewerRef])
   return (
     <Box
-      sx={{ ...sx, fontSize: '0.9375rem' }}
+      sx={{
+        ...sx,
+        fontSize: '0.9375rem',
+        '& .toastui-editor-contents': {
+          '& p': {
+            color: 'text.alternative',
+          },
+        },
+      }}
       ref={viewerRef}
-      color={'text.alternative'}
     />
   )
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,4 +1,3 @@
-
 /* pretendard variable 폰트 */
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 
@@ -45,4 +44,22 @@ body * {
 }
 .no-scroll::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
+}
+
+/* .toastui-editor-contents p {
+  color: #1a1a1a !important;
+} */
+
+/* 라이트 모드일 때 */
+@media (prefers-color-scheme: light) {
+  .toastui-editor-contents p {
+    color: #1a1a1a !important;
+  }
+}
+
+/* 다크 모드일 때 */
+@media (prefers-color-scheme: dark) {
+  .toastui-editor-contents p {
+    color: #f6f6f6 !important;
+  }
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -45,21 +45,3 @@ body * {
 .no-scroll::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
 }
-
-/* .toastui-editor-contents p {
-  color: #1a1a1a !important;
-} */
-
-/* 라이트 모드일 때 */
-@media (prefers-color-scheme: light) {
-  .toastui-editor-contents p {
-    color: #1a1a1a !important;
-  }
-}
-
-/* 다크 모드일 때 */
-@media (prefers-color-scheme: dark) {
-  .toastui-editor-contents p {
-    color: #f6f6f6 !important;
-  }
-}


### PR DESCRIPTION
### 작업사항

다크 모드에선 toast-viewer에서 기본적으로 적용하는 폰트 컬러가 시인성이 낮아서, 시스템 환경에 맞는 컬러로 변경하였습니다.

![Screen Recording 2024-02-02 at 3 48 56 PM](https://github.com/peer-42seoul/Peer-Frontend/assets/62472550/be6be3a0-c4cd-4fd5-8437-0e0c54393ff8)

```css


/* 라이트 모드일 때 */
@media (prefers-color-scheme: light) {
  .toastui-editor-contents p {
    color: #1a1a1a !important;
  }
}

/* 다크 모드일 때 */
@media (prefers-color-scheme: dark) {
  .toastui-editor-contents p {
    color: #f6f6f6 !important;
  }
}

```