### PR TITLE
[J-TB] 좋아요 GET 로직 추가, 레이아웃 수정, 공유 기능 연결

### DIFF
--- a/src/app/recruit/[id]/panel/ApplyDefaultButton.tsx
+++ b/src/app/recruit/[id]/panel/ApplyDefaultButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mui/material'
+import { Button, Typography } from '@mui/material'
 import React from 'react'
 import { SxProps } from '@mui/system'
 import { Theme } from '@mui/material/styles'
@@ -20,7 +20,9 @@ const ApplyDefaultButton = ({
       sx={sx}
       disabled={disabled}
     >
-      지원하기
+      <Typography variant={'Body1'} color={'white'}>
+        지원하기
+      </Typography>
     </Button>
   )
 }

--- a/src/app/recruit/[id]/panel/ApplyDrawerButton.tsx
+++ b/src/app/recruit/[id]/panel/ApplyDrawerButton.tsx
@@ -1,4 +1,11 @@
-import { Button, Drawer, List, ListItem, ListItemButton } from '@mui/material'
+import {
+  Button,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  Typography,
+} from '@mui/material'
 import React, { useState } from 'react'
 import { IRole } from '@/types/IPostDetail'
 
@@ -22,15 +29,26 @@ const ApplyDrawerButton = ({
         sx={{ zIndex: 1500 }}
       >
         <List>
-          {roleList.map(({ name }) => (
-            <ListItem key={name}>
+          {roleList.map((role) => (
+            <ListItem key={role?.name}>
               <ListItemButton
                 onClick={() => {
                   setOpen(false)
-                  handleApply(name)
+                  handleApply(role?.name)
                 }}
               >
-                {name}
+                <Typography
+                  variant={'Body1'}
+                  noWrap
+                  sx={{
+                    color: 'text.normal',
+                    '&:hover ': {
+                      color: 'purple.normal',
+                    },
+                  }}
+                >
+                  {role?.name} {role?.current}/{role?.number}
+                </Typography>
               </ListItemButton>
             </ListItem>
           ))}
@@ -45,7 +63,9 @@ const ApplyDrawerButton = ({
           setOpen(true)
         }}
       >
-        지원하기
+        <Typography variant={'Body1'} color={'white'}>
+          지원하기
+        </Typography>
       </Button>
     </>
   )

--- a/src/app/recruit/[id]/panel/ApplyFormButton.tsx
+++ b/src/app/recruit/[id]/panel/ApplyFormButton.tsx
@@ -51,6 +51,7 @@ const ApplyFormButton = ({
             roleList={roleList}
             onApply={handleApply}
             disabled={checkIsFull}
+            sx={{ width: '8.25rem', marginTop: '2rem' }}
           />
         ) : (
           <ApplyDefaultButton

--- a/src/app/recruit/[id]/panel/ApplyMenuButton.tsx
+++ b/src/app/recruit/[id]/panel/ApplyMenuButton.tsx
@@ -1,20 +1,31 @@
 import React from 'react'
-import { Button, Menu, MenuItem, Typography } from '@mui/material'
+import {
+  alpha,
+  Button,
+  Menu,
+  MenuItem,
+  SxProps,
+  Typography,
+} from '@mui/material'
 import { KeyboardArrowDown } from '@mui/icons-material'
 import { IRole } from '@/types/IPostDetail'
+import { useTheme } from '@mui/system'
 
 const ApplyMenuButton = ({
   roleList,
   onApply,
   disabled,
+  sx,
 }: {
   roleList: IRole[]
   onApply: (selectedRole: string) => void
   disabled: boolean
+  sx: SxProps
 }) => {
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(
     null,
   )
+  const theme = useTheme()
 
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
     if (menuAnchorEl) {
@@ -38,21 +49,48 @@ const ApplyMenuButton = ({
         disableElevation
         onClick={handleMenuClick}
         endIcon={<KeyboardArrowDown />}
+        sx={sx}
       >
-        <Typography>지원하기</Typography>
+        <Typography variant={'Body1'} color={'white'}>
+          지원하기
+        </Typography>
       </Button>
       <Menu
         anchorEl={menuAnchorEl}
         open={Boolean(menuAnchorEl)}
         onClose={handleClose}
+        sx={{
+          '& .MuiPaper-root': {
+            backgroundColor: alpha(theme.palette.purple.tinted, 0.2),
+          },
+        }}
       >
         {roleList?.map((role, index) => (
           <MenuItem
             key={index}
             onClick={() => onApply(role?.name)}
             disabled={role?.current >= role?.number}
+            sx={{
+              ' &.MuiMenuItem-root': {
+                width: '8.25rem',
+                display: 'flex',
+                padding: '0.25rem',
+                justifyContent: 'center',
+              },
+            }}
           >
-            {role?.name}
+            <Typography
+              variant={'Body1'}
+              noWrap
+              sx={{
+                color: 'text.normal',
+                '&:hover ': {
+                  color: 'purple.normal',
+                },
+              }}
+            >
+              {role?.name} {role?.current}/{role?.number}
+            </Typography>
           </MenuItem>
         ))}
       </Menu>

--- a/src/app/recruit/[id]/panel/RecruitInfo.tsx
+++ b/src/app/recruit/[id]/panel/RecruitInfo.tsx
@@ -26,20 +26,31 @@ const RecruitInfo = ({ data, type, children, pc }: RecruitInfoProps) => {
             width={'18.5rem'}
             height={'12.5rem'}
           />
-          <Box display="flex" flexDirection="column" gap={2}>
-            <Stack gap={'1rem'} direction="row" alignItems={'center'}>
-              <TypeChip type={type} />
-              <RecruitTitle title={data?.title} status={data?.status} />
-            </Stack>
-            <Stack gap={'1rem'} direction="row" alignItems={'center'}>
-              <OthersProfile
-                userId={data?.leader_id}
-                name={data?.leader_nickname}
-              >
-                <Avatar alt="avatar" src={data?.leader_image} sizes={'small'} />
-              </OthersProfile>
-              <Typography variant={'Body2'}>{data?.teamName}</Typography>
-              <LinkButton href={data?.link} variant={'contained'} />
+          <Box
+            display="flex"
+            flexDirection="column"
+            gap={2}
+            justifyContent={'space-between'}
+          >
+            <Stack gap={'1rem'}>
+              <Stack gap={'1rem'} direction="row" alignItems={'center'}>
+                <TypeChip type={type} />
+                <RecruitTitle title={data?.title} status={data?.status} />
+              </Stack>
+              <Stack gap={'1rem'} direction="row" alignItems={'center'}>
+                <OthersProfile
+                  userId={data?.leader_id}
+                  name={data?.leader_nickname}
+                >
+                  <Avatar
+                    alt="avatar"
+                    src={data?.leader_image}
+                    sizes={'small'}
+                  />
+                </OthersProfile>
+                <Typography variant={'Body2'}>{data?.teamName}</Typography>
+                <LinkButton href={data?.link} variant={'contained'} />
+              </Stack>
             </Stack>
             {/*지원 버튼*/}
             {children}

--- a/src/app/recruit/[id]/panel/RecruitInfo.tsx
+++ b/src/app/recruit/[id]/panel/RecruitInfo.tsx
@@ -26,31 +26,20 @@ const RecruitInfo = ({ data, type, children, pc }: RecruitInfoProps) => {
             width={'18.5rem'}
             height={'12.5rem'}
           />
-          <Box
-            display="flex"
-            flexDirection="column"
-            gap={2}
-            justifyContent={'space-between'}
-          >
-            <Stack gap={'1rem'}>
-              <Stack gap={'1rem'} direction="row" alignItems={'center'}>
-                <TypeChip type={type} />
-                <RecruitTitle title={data?.title} status={data?.status} />
-              </Stack>
-              <Stack gap={'1rem'} direction="row" alignItems={'center'}>
-                <OthersProfile
-                  userId={data?.leader_id}
-                  name={data?.leader_nickname}
-                >
-                  <Avatar
-                    alt="avatar"
-                    src={data?.leader_image}
-                    sizes={'small'}
-                  />
-                </OthersProfile>
-                <Typography variant={'Body2'}>{data?.teamName}</Typography>
-                <LinkButton href={data?.link} variant={'contained'} />
-              </Stack>
+          <Box display="flex" flexDirection="column" gap={2}>
+            <Stack gap={'1rem'} direction="row" alignItems={'center'}>
+              <TypeChip type={type} />
+              <RecruitTitle title={data?.title} status={data?.status} />
+            </Stack>
+            <Stack gap={'1rem'} direction="row" alignItems={'center'}>
+              <OthersProfile
+                userId={data?.leader_id}
+                name={data?.leader_nickname}
+              >
+                <Avatar alt="avatar" src={data?.leader_image} sizes={'small'} />
+              </OthersProfile>
+              <Typography variant={'Body2'}>{data?.teamName}</Typography>
+              <LinkButton href={data?.link} variant={'contained'} />
             </Stack>
             {/*지원 버튼*/}
             {children}

--- a/src/app/recruit/[id]/panel/RecruitQuickMenu.tsx
+++ b/src/app/recruit/[id]/panel/RecruitQuickMenu.tsx
@@ -2,15 +2,19 @@ import { IconButton, Stack, Tooltip } from '@mui/material'
 import FavoriteButton from '@/components/FavoriteButton'
 import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
 import React from 'react'
-import SirenIcon from '@/app/recruit/[id]/panel/SirenIcon'
 import { usePathname, useSearchParams } from 'next/navigation'
+import { handleShare } from '@/components/dropdownMenu/ShareMenuItem'
 
 const RecruitQuickMenu = ({
   favorite,
   recruit_id,
+  title,
+  content,
 }: {
   favorite: boolean | undefined
   recruit_id: number
+  title: string
+  content: string
 }) => {
   const path = usePathname()
   const type = useSearchParams().get('type')
@@ -23,15 +27,24 @@ const RecruitQuickMenu = ({
         redirect_url={`${path}?type=${type}`}
       />
       <Tooltip title={'공유'}>
-        <IconButton onClick={() => {}}>
+        <IconButton
+          onClick={() => {
+            handleShare(
+              title,
+              `${path}?type=${type}`,
+              content,
+              `피어에서 동료를 구해보세요! 이런 프로젝트가 있어요!`,
+            )
+          }}
+        >
           <ShareOutlinedIcon sx={{ color: 'purple.strong' }} />
         </IconButton>
       </Tooltip>
-      <Tooltip title={'신고'}>
-        <IconButton onClick={() => {}}>
-          <SirenIcon />
-        </IconButton>
-      </Tooltip>
+      {/*<Tooltip title={'신고'}>*/}
+      {/*  <IconButton onClick={() => {}}>*/}
+      {/*    <SirenIcon />*/}
+      {/*  </IconButton>*/}
+      {/*</Tooltip>*/}
     </Stack>
   )
 }

--- a/src/components/dropdownMenu/ShareMenuItem.tsx
+++ b/src/components/dropdownMenu/ShareMenuItem.tsx
@@ -5,52 +5,59 @@ import IconMenuItem from './IconMenuItem'
 import * as style from './dropdownMenu.styles'
 import { ShareIcon } from '@/icons'
 
+interface IShareProps {
+  title: string
+  url: string
+  content: string
+  message?: string
+}
+
+export const handleShare = (
+  title: string,
+  url: string,
+  content: string,
+  message?: string,
+) => {
+  if (navigator.share) {
+    navigator
+      .share({
+        title: title,
+        url: url,
+        text: content,
+      })
+      .catch((e) => {
+        console.error(e)
+      })
+  } else {
+    if (navigator.clipboard) {
+      navigator.clipboard
+        .writeText(message || url)
+        .then(() => alert('클립보드에 복사되었습니다.'))
+        .catch((e) => {
+          console.error(e)
+        })
+    } else {
+      const textarea = document.createElement('textarea')
+      textarea.value = message || url
+      textarea.id = 'temp'
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textarea)
+      alert('클립보드에 복사되었습니다.')
+    }
+  }
+}
+
 const ShareMenuItem = ({
   title,
   url,
   content,
   message, // handleClose,
-}: {
-  title: string
-  url: string
-  content: string
-  message?: string // 클립보드에 복사할 메세지 ex) '피어에서 동료를 구해보세요! 이런 프로젝트가 있어요! ${url}'
-  // handleClose: () => void
-}) => {
-  const handleShare = () => {
-    if (navigator.share) {
-      navigator
-        .share({
-          title: title,
-          url: url,
-          text: content,
-        })
-        .catch((e) => {
-          console.error(e)
-        })
-    } else {
-      if (navigator.clipboard) {
-        navigator.clipboard
-          .writeText(message || url)
-          .then(() => alert('클립보드에 복사되었습니다.'))
-          .catch((e) => {
-            console.error(e)
-          })
-      } else {
-        const textarea = document.createElement('textarea')
-        textarea.value = message || url
-        textarea.id = 'temp'
-        document.body.appendChild(textarea)
-        textarea.select()
-        document.execCommand('copy')
-        document.body.removeChild(textarea)
-        alert('클립보드에 복사되었습니다.')
-      }
-    }
-  }
+}: IShareProps) => {
   return (
     <IconMenuItem
-      action={handleShare}
+      action={() => handleShare(title, url, content, message)}
       icon={
         <ShareIcon
           sx={{


### PR DESCRIPTION
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/c6122019-4bb3-4265-b6b8-7e6f20a0c513)
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/fdec403c-013a-435a-b627-6052725ce956)

* 모집글 뷰도 ssr로 렌더링 되기 때문에, 좋아요를 get하는 로직을 따로 추가해주었습니다.
* 지원하기 버튼 위치를 조정했습니다. 
* 모집글에 있던 신고하기 버튼은 없애고 (어차피 유저로 신고할테니까) pc뷰 공유 버튼에 다른 컴포넌트에 있던 공유 기능을 가져와 연결했습니다. 이 과정에서 share function을 기존 컴포넌트에서 분리했는데, 혹시 문제가 있을지 확인부탁드립니다.
* 지원 시 버튼에 몇명 남았는지도 보여주었습니다. (- 역할이 있는 경우에만 넣었는데, 역할없는 스터디에도 필요할까요? 지금 스터디는 드롭다운이 아닌데, 그냥 버튼에 지원하기 옆에 명수를 적어줄지 아니면 그냥 스터디 버튼도 드롭다운으로 바꿀지 고민입니다.)

@todo 
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/9a7e1533-b1ff-4b23-89fe-aa048694d385)
실제로 공유해보면 이런식으로 뜨는데 맞는 작동방식인지 확인해봐야 할 것 같습니다.