### PR TITLE
[D-TP] 팀 페이지 접근 제한 로직 추가

### DIFF
--- a/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
+++ b/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Box } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
 import {
@@ -24,19 +25,33 @@ const NoticeList = ({
       `/api/v1/team-page/notice/${teamId}?keyword=&${keyword}pageSize=${10}`,
       (url: string) => axiosWithAuth.get(url).then((res) => res.data),
     )
+  const router = useRouter()
   useEffect(() => {
     // keyword가 바뀔 때마다 size를 1로 초기화 (다시 첫 페이지부터 불러오기)
     if (!isLoading && size !== 1) setSize(1)
   }, [keyword])
 
-  if (!data || error) return <StatusMessage message="문제가 발생했습니다." />
-  if (!data && isLoading)
-    return <StatusMessage message="공지사항을 불러오는 중입니다..." />
-  if (data.length === 0 || data[0].content.length === 0)
-    return <StatusMessage message="등록된 글이 없습니다." />
+  if (error) {
+    if (error.status === 403) {
+      alert('팀 페이지에 접근할 권한이 없습니다.')
+    } else {
+      alert('팀 페이지에 접근할 수 없습니다.')
+    }
+    router.push('/team-list')
+    return <StatusMessage message="문제가 발생했습니다." />
+  }
+
+  if (!isLoading && !data) {
+    alert('팀 페이지에 접근할 수 없습니다.')
+    router.push('/team-list')
+    return <StatusMessage message="문제가 발생했습니다." />
+  }
+
+  if (isLoading) return <StatusMessage message="로딩중입니다..." />
+
   return (
     <ListStack>
-      {data.map((page, index) => {
+      {data?.map((page, index) => {
         return (
           <Fragment key={index}>
             {page.content.map((notice: ITeamNotice) => {

--- a/src/app/teams/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/[id]/panel/TeamInfoContainer.tsx
@@ -1,6 +1,8 @@
+import { useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import { Avatar, Stack, Typography } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
+import CuCircularProgress from '@/components/CuCircularProgress'
 import { ITeamInfo } from '@/types/ITeamInfo'
 import { StatusIcon, IconInfo } from './TeamInfoComponent'
 import { useEffect } from 'react'
@@ -15,6 +17,7 @@ const TeamInfoContainer = ({ id }: { id: number }) => {
     (url: string) => axiosInstance(url).then((res) => res.data),
   )
   const { setHeaderTitle } = useHeaderStore()
+  const router = useRouter()
 
   // set header
   useEffect(() => {
@@ -26,41 +29,48 @@ const TeamInfoContainer = ({ id }: { id: number }) => {
     }
   }, [data])
 
-  if (isLoading) {
-    return <Typography>로딩중...</Typography>
+  if (error) {
+    if (error.status === 403) alert('팀 페이지에 접근할 권한이 없습니다.')
+    else if (error.status === 404) alert('팀 페이지가 존재하지 않습니다.')
+    else alert('팀 페이지에 접근할 수 없습니다.')
+    router.push('/team-list')
+    return <CuCircularProgress color={'primary'} />
   }
 
-  if (error || !data) {
-    switch (error?.status) {
-      case 403:
-        return <Typography>권한이 없습니다.</Typography>
-      case 404:
-        return <Typography>존재하지 않는 팀입니다.</Typography>
-      default:
-        return <Typography>에러가 발생했습니다.</Typography>
-    }
+  if (!isLoading && !data) {
+    alert('팀 페이지에 접근할 수 없습니다.')
+    router.push('/team-list')
+    return <CuCircularProgress color={'primary'} />
   }
 
   return (
     <>
       <Stack direction={'row'} spacing={1}>
-        <Avatar
-          alt="team logo"
-          variant="rounded"
-          sx={{ width: 89, height: 92, border: 1, borderRadius: 1.2 }}
-          src={data.teamPicturePath ? data.teamPicturePath : defaultLogoPath}
-        />
-        <Stack>
-          <Stack direction={'row'}>
-            <Typography variant="h5">{data.name}</Typography>
-            <StatusIcon status={data.status} />
-          </Stack>
-          <Stack direction={'row'}>
-            <IconInfo type="MEMBER" text={data.memberCount.toString()} />
-            <IconInfo type="LEADER" text={data.leaderName} />
-            <IconInfo type="DATE" text={data.createdAt} />
-          </Stack>
-        </Stack>
+        {isLoading || !data ? (
+          <CuCircularProgress color={'primary'} />
+        ) : (
+          <>
+            <Avatar
+              alt="team logo"
+              variant="rounded"
+              sx={{ width: 89, height: 92, border: 1, borderRadius: 1.2 }}
+              src={
+                data.teamPicturePath ? data.teamPicturePath : defaultLogoPath
+              }
+            />
+            <Stack>
+              <Stack direction={'row'}>
+                <Typography variant="h5">{data.name}</Typography>
+                <StatusIcon status={data.status} />
+              </Stack>
+              <Stack direction={'row'}>
+                <IconInfo type="MEMBER" text={data.memberCount.toString()} />
+                <IconInfo type="LEADER" text={data.leaderName} />
+                <IconInfo type="DATE" text={data.createdAt} />
+              </Stack>
+            </Stack>
+          </>
+        )}
       </Stack>
     </>
   )

--- a/src/app/teams/[id]/setting/page.tsx
+++ b/src/app/teams/[id]/setting/page.tsx
@@ -41,16 +41,12 @@ const TeamsSetupPage = ({ params }: { params: { id: string } }) => {
         teamName: data?.team.name,
       },
       (data: any) => {
-        console.log('whoAmI receive')
-        console.log(data)
         setMyInfo(data)
       },
     )
   }, [])
 
   if (isLoading) return <Typography>로딩중</Typography>
-
-  console.log(data)
 
   return (
     <Stack

--- a/src/components/board/ListPanel.tsx
+++ b/src/components/board/ListPanel.tsx
@@ -13,6 +13,7 @@ import { PlusIcon, SearchIcon } from '@/icons'
 import * as style from './ListPanel.style'
 import CuButton from '../CuButton'
 import CuTextField from '../CuTextField'
+import CuCircularProgress from '../CuCircularProgress'
 
 interface IChildrenProps {
   children: React.ReactNode
@@ -186,6 +187,7 @@ export const StatusMessage = ({ message }: { message: string }) => {
       >
         {message}
       </Typography>
+      <CuCircularProgress color={'primary'} />
     </ListStack>
   )
 }


### PR DESCRIPTION
### 작업 내용

팀 페이지 접근 제한 로직을 추가했습니다.
팀 메인 페이지, 공지사항 페이지, 게시판 페이지(는 이미 제한 로직이 추가되어 있었음), 설정 페이지에서
권한이 없거나 에러가 발생한 경우에 alert를 띄우고 팀 리스트 페이지로 이동하도록 했습니다.

### 관련 이슈

- close #485