### PR TITLE
[C-TB] 모바일 네비게이션바 safe area 문제

### DIFF
--- a/src/app/panel/MainLayout.tsx
+++ b/src/app/panel/MainLayout.tsx
@@ -5,16 +5,9 @@ import Header from './layout-panel/Header'
 import { usePathname } from 'next/navigation'
 import MobileNav from './layout-panel/MobileNav'
 import PcNav from './layout-panel/PcNav'
-import { useEffect, useState } from 'react'
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname()
-  const [innerHeight, setInnerHeight] = useState<number>(0)
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setInnerHeight(window.innerHeight)
-    }
-  }, [])
 
   // if (
   //   pathname === '/login' ||
@@ -34,52 +27,32 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
 
   if (pathname === '/showcase' || pathname === '/hitchhiking') {
     return (
-      <Box
-        sx={{
-          backgroundColor: 'background.primary',
-          height: innerHeight === 0 ? '100dvh' : innerHeight,
-        }}
-      >
+      <Box sx={{ backgroundColor: 'background.primary', height: '100dvh' }}>
         <div className="mobile-layout">
-          <Box sx={{ paddingBottom: '64px' }}>{children}</Box>
+          <Box sx={{ marginBottom: '64px' }}>{children}</Box>
           <MobileNav />
         </div>
         <div className="pc-layout">
           <PcNav />
-          <Box sx={{ paddingY: '64px' }}>{children}</Box>
+          <Box sx={{ marginY: '64px' }}>{children}</Box>
         </div>
       </Box>
     )
   }
 
   return (
-    <Box
-      sx={{
-        backgroundColor: 'background.primary',
-        height: innerHeight === 0 ? '100dvh' : innerHeight,
-        overflowY: 'auto',
-        overflowX: 'hidden',
-        '&::-webkit-scrollbar': {
-          display: 'none',
-        },
-      }}
-    >
+    <Box sx={{ backgroundColor: 'background.primary', height: '100dvh' }}>
       <div className="mobile-layout">
         <Header pathname={pathname} />
         {/* margin은 header와 bottom appbar의 크기 */}
-        <Box
-          sx={{
-            paddingTop: '3.375rem',
-            paddingBottom: '64px',
-          }}
-        >
+        <Box sx={{ marginTop: '3.375rem', marginBottom: '64px' }}>
           {children}
         </Box>
         <MobileNav />
       </div>
       <div className="pc-layout">
         <PcNav />
-        <Box sx={{ paddingY: '64px' }}>{children}</Box>
+        <Box sx={{ marginY: '64px' }}>{children}</Box>
       </div>
     </Box>
   )

--- a/src/app/panel/MainLayout.tsx
+++ b/src/app/panel/MainLayout.tsx
@@ -5,9 +5,16 @@ import Header from './layout-panel/Header'
 import { usePathname } from 'next/navigation'
 import MobileNav from './layout-panel/MobileNav'
 import PcNav from './layout-panel/PcNav'
+import { useEffect, useState } from 'react'
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname()
+  const [innerHeight, setInnerHeight] = useState<number>(0)
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setInnerHeight(window.innerHeight)
+    }
+  }, [])
 
   // if (
   //   pathname === '/login' ||
@@ -27,32 +34,52 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
 
   if (pathname === '/showcase' || pathname === '/hitchhiking') {
     return (
-      <Box sx={{ backgroundColor: 'background.primary', minHeight: '100svh' }}>
+      <Box
+        sx={{
+          backgroundColor: 'background.primary',
+          height: innerHeight === 0 ? '100dvh' : innerHeight,
+        }}
+      >
         <div className="mobile-layout">
-          <Box sx={{ marginBottom: '64px' }}>{children}</Box>
+          <Box sx={{ paddingBottom: '64px' }}>{children}</Box>
           <MobileNav />
         </div>
         <div className="pc-layout">
           <PcNav />
-          <Box sx={{ marginY: '64px' }}>{children}</Box>
+          <Box sx={{ paddingY: '64px' }}>{children}</Box>
         </div>
       </Box>
     )
   }
 
   return (
-    <Box sx={{ backgroundColor: 'background.primary', minHeight: '100dvh' }}>
+    <Box
+      sx={{
+        backgroundColor: 'background.primary',
+        height: innerHeight === 0 ? '100dvh' : innerHeight,
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+      }}
+    >
       <div className="mobile-layout">
         <Header pathname={pathname} />
         {/* margin은 header와 bottom appbar의 크기 */}
-        <Box sx={{ marginTop: '3.375rem', marginBottom: '64px' }}>
+        <Box
+          sx={{
+            paddingTop: '3.375rem',
+            paddingBottom: '64px',
+          }}
+        >
           {children}
         </Box>
         <MobileNav />
       </div>
       <div className="pc-layout">
         <PcNav />
-        <Box sx={{ marginY: '64px' }}>{children}</Box>
+        <Box sx={{ paddingY: '64px' }}>{children}</Box>
       </div>
     </Box>
   )

--- a/src/app/panel/layout-panel/MobileNav.tsx
+++ b/src/app/panel/layout-panel/MobileNav.tsx
@@ -59,7 +59,7 @@ const MobileNav = () => {
         onChange={(event, newValue) => {
           setValue(newValue)
         }}
-        sx={{ paddingX: '1rem' }}
+        sx={{ paddingX: '1rem', paddingBottom: '1.25rem' }}
       >
         <BottomNavigationAction
           sx={bottomNavStyle}

--- a/src/app/panel/layout-panel/MobileNav.tsx
+++ b/src/app/panel/layout-panel/MobileNav.tsx
@@ -18,7 +18,7 @@ import { bottomNavStyle } from './MobileNav.style'
 
 const MobileNav = () => {
   const [value, setValue] = useState<
-    'home' | 'hitchhiking' | 'team-list' | 'showcase' | 'my-page'
+    'home' | 'hitchhiking' | 'team-list' | 'showcase' | 'my-page' | ''
   >('home')
   const pathname = usePathname()
   const router = useRouter()
@@ -36,6 +36,8 @@ const MobileNav = () => {
       else setValue('my-page')
     } else if (pathname.startsWith('/showcase')) {
       setValue('showcase')
+    } else if (pathname.startsWith('/login')) {
+      setValue('')
     }
   }, [pathname])
 

--- a/src/app/panel/layout-panel/PcNav.tsx
+++ b/src/app/panel/layout-panel/PcNav.tsx
@@ -15,8 +15,9 @@ import PeerLogo from '@/app/panel/layout-panel/PeerLogo'
 import AlertIcon from '@/app/panel/layout-panel/AlertIcon'
 import SearchButton from '@/app/panel/main-page/SearchButton'
 import Link from 'next/link'
-import { BorderColor, Favorite } from '@mui/icons-material'
+import { Favorite } from '@mui/icons-material'
 import { BetaIcon } from '@/components/BetaBadge'
+import WriteIcon from '@/icons/Nav/WriteIcon'
 
 const PcNav = () => {
   const [value, setValue] = useState<
@@ -186,7 +187,7 @@ const PcNav = () => {
           >
             {isTablet ? (
               <IconButton>
-                <BorderColor color={'primary'} />
+                <WriteIcon color={'primary'} />
               </IconButton>
             ) : (
               <Button
@@ -195,7 +196,7 @@ const PcNav = () => {
                 }}
                 variant="contained"
               >
-                모집글 쓰기
+                모집글쓰기
               </Button>
             )}
           </Link>

--- a/src/app/panel/main-page/FloatEditButton.tsx
+++ b/src/app/panel/main-page/FloatEditButton.tsx
@@ -7,7 +7,7 @@ const FloatEditButton = () => {
   const { isLogin } = useAuthStore()
 
   return (
-    <Fab color="primary" aria-label="edit" size={'medium'}>
+    <Fab color="primary" aria-label="edit" size={'large'}>
       <Link
         style={{ width: '100%', height: '100%' }}
         href={isLogin ? '/recruit/write' : '/login?redirect=/recruit/write'}

--- a/styles/global.css
+++ b/styles/global.css
@@ -21,20 +21,24 @@ body * {
   .mobile-layout {
     display: flex;
     flex-direction: column;
+    height: 100%;
   }
   .pc-layout {
     display: none;
+    height: 100%;
   }
 }
 
 @media (min-width: 481px) {
   .mobile-layout {
     display: none;
+    height: 100%;
   }
 
   .pc-layout {
     display: flex;
     flex-direction: column;
+    height: 100%;
   }
 }
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -21,24 +21,20 @@ body * {
   .mobile-layout {
     display: flex;
     flex-direction: column;
-    height: 100%;
   }
   .pc-layout {
     display: none;
-    height: 100%;
   }
 }
 
 @media (min-width: 481px) {
   .mobile-layout {
     display: none;
-    height: 100%;
   }
 
   .pc-layout {
     display: flex;
     flex-direction: column;
-    height: 100%;
   }
 }
 


### PR DESCRIPTION
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/38460a95-89a1-441c-ad5a-6e60773092fd)

* ios의 하단의 safe area에 하단 네비게이션이 겹치지 않도록 네비게이션에 padding을 주었습니다 (대신 safe area가 거의 없는 기기에도 padding이 생겨버렸습니다...)
* env (https://developer.mozilla.org/en-US/docs/Web/CSS/env)를 통해 padding을 조건부로 주고 싶었는데 생각대로 잘 작동하지 않아 임시방편으로 해둔 조치입니다. 추후 더 좋은 방법이 있으면 바꿀 예정입니다. 