### PR TITLE
[C-SIGN] OAuth 로그인, 연동 시 fobidden 페이지로 반환되는 경우 처리

### DIFF
--- a/src/app/login/forbidden/page.tsx
+++ b/src/app/login/forbidden/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { CircularProgress, Typography, Stack } from '@mui/material'
+import { useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+import useToast from '@/states/useToast'
+import { useRouter } from 'next/navigation'
+
+const LoginForbidden = () => {
+  const searchParams = useSearchParams()
+  const code = searchParams.get('code')
+  const { openToast } = useToast()
+  const router = useRouter()
+
+  const handleForbidden = () => {
+    if (code === 'blocked') {
+      openToast({
+        message: '차단된 계정입니다. 관리자에게 문의하세요.',
+        severity: 'error',
+      })
+      router.push('/login')
+    } else if (code === 'already_link') {
+      openToast({
+        message: '이미 연동이 완료된 소셜계정입니다.',
+        severity: 'error',
+      })
+      router.push('/my-page')
+    } else if (code === 'duplicate') {
+      openToast({
+        message: '이미 이 계정으로 연동되어 있습니다.',
+        severity: 'error',
+      })
+      router.push('/my-page')
+    } else if (code === 'failed') {
+      openToast({
+        message: '소셜 로그인에 문제가 발생했습니다.',
+        severity: 'error',
+      })
+      router.push('/login')
+    }
+  }
+
+  useEffect(() => {
+    handleForbidden()
+  }, [])
+  return (
+    <Stack
+      sx={{
+        width: '100%',
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+      }}
+    >
+      <CircularProgress />
+      <Typography>계정 처리 중...</Typography>
+    </Stack>
+  )
+}
+
+export default LoginForbidden

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -24,7 +24,7 @@ const Login = () => {
   const [showPassword, setShowPassword] = useState<'password' | 'text'>(
     'password',
   )
-  const { login } = useAuthStore()
+  const { isLogin, login } = useAuthStore()
 
   const { openToast, closeToast } = useToast()
 
@@ -78,6 +78,8 @@ const Login = () => {
         message: '로그인이 필요한 서비스입니다.',
         severity: 'error',
       })
+    } else if (isLogin) {
+      router.push('/')
     }
   }, [])
 

--- a/src/components/EncryptedSender.tsx
+++ b/src/components/EncryptedSender.tsx
@@ -100,8 +100,9 @@ const EncryptedSender = ({
       if (setIsLoading) setIsLoading(false)
     } catch (e: any) {
       console.log(e)
-      if (onError)
+      if (onError) {
         onError(e?.response?.data?.message ?? '알 수 없는 오류가 발생했습니다.')
+      }
       if (setIsLoading) setIsLoading(false)
       setPayload(null)
     }


### PR DESCRIPTION
- OAuth 로그인 또는 연동 상황에서 정지된 계정, 이미 연결된 계정, oauth 자체 오류 등이 발생하면 백에서 login/forbidden 페이지와 code를 쿼리로 반환합니다. 이에 따라 toast message와 page redirection을 처리했습니다. 