### PR TITLE
[toast editor] 본문 내 이미지 삽입 기능 개선

### DIFF
--- a/src/components/ToastUIEditor.tsx
+++ b/src/components/ToastUIEditor.tsx
@@ -18,6 +18,7 @@ const ToastEditor = ({
   height = '30rem',
   editorRef,
 }: IToastEditorProps) => {
+  const API_URL = process.env.NEXT_PUBLIC_API_URL
   const themed = useTheme()
   const editorElementRef = useRef<HTMLDivElement>(null)
   const toggleDark = () => {
@@ -45,6 +46,24 @@ const ToastEditor = ({
       previewStyle: previewStyle,
       height: height,
       initialValue: initialValue,
+      hooks: {
+        addImageBlobHook: async (blob : Blob, callback : (url: string, text: string) => void) => {
+          const formData = new FormData();
+          formData.append('image', blob);
+    
+          try {
+            const response = await fetch(`${API_URL}/api/v1/editor/image`, {
+              method: 'POST',
+              body: formData,
+            });
+            const data = await response.json();
+            const imageUrl = data.url; // 서버에서 반환된 이미지 URL
+            callback(imageUrl, '이미지 대체 텍스트');
+          } catch (error) {
+            console.error('이미지 업로드 실패', error);
+          }
+        },
+      } 
     })
     toggleDark()
 

--- a/src/types/ToastUI/editor.d.ts
+++ b/src/types/ToastUI/editor.d.ts
@@ -18,6 +18,8 @@ declare module '@toast-ui/editor' {
     initialEditType?: 'markdown' | 'wysiwyg'
     previewStyle?: 'tab' | 'vertical'
     height?: string
+    hooks: any
+
   }
 
   export class Editor {
@@ -29,5 +31,7 @@ declare module '@toast-ui/editor' {
     setHtml(html: string): void
     on(event: string, callback: Function): void
     destroy(): void
+    hooks(): any
+
   }
 }

--- a/src/types/ToastUI/editor.d.ts
+++ b/src/types/ToastUI/editor.d.ts
@@ -18,7 +18,7 @@ declare module '@toast-ui/editor' {
     initialEditType?: 'markdown' | 'wysiwyg'
     previewStyle?: 'tab' | 'vertical'
     height?: string
-    hooks: any
+    hooks?: any
 
   }
 


### PR DESCRIPTION
# 개선상황
- base64 가 그대로 본문내에 삽입되어 백엔드에 전송되던 상황
- base64 이미지파일을 /api/v1/editor/image 엔드포인트로 post 해서 보내면 response로 nhn object storage url 을 받음.
- 그 url을 바로 에디터 내 본문에 `![대체이미지](imageUrl)` 형식으로 반영됨.

# 참고
- 아직 /api/v1/editor/image 엔드포인트의 api 는 백엔드로직이 작업중임.
- 이 코드는 테스트 하지않은 코드입니다. 테스트 필요.