### PR TITLE
[PUBLIC] 팀 게시판 튜토리얼 버튼 위치 변경

### DIFF
--- a/src/app/teams/[id]/board/@list/page.tsx
+++ b/src/app/teams/[id]/board/@list/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import { AxiosResponse, isAxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { Stack } from '@mui/material'
+import { Box, Stack } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
 import {
   ListPageContainer,
@@ -73,8 +73,10 @@ const TeamBoard = ({ params }: { params: { id: string } }) => {
               alignItems={'center'}
               justifyContent={'space-between'}
             >
-              <BoardDropdown boardData={boardList} />
-              <Tutorial content={<TeamBoardTutorial />} />
+              <Box>
+                <BoardDropdown boardData={boardList} />
+                <Tutorial content={<TeamBoardTutorial />} />
+              </Box>
               <Stack direction={'row'} spacing={'0.5rem'}>
                 <IconButtonContainer
                   setKeyword={setKeyword}

--- a/src/components/board/ListPanel.tsx
+++ b/src/components/board/ListPanel.tsx
@@ -13,7 +13,6 @@ import { PlusIcon, SearchIcon } from '@/icons'
 import * as style from './ListPanel.style'
 import CuButton from '../CuButton'
 import CuTextField from '../CuTextField'
-import CuCircularProgress from '../CuCircularProgress'
 
 interface IChildrenProps {
   children: React.ReactNode
@@ -187,7 +186,6 @@ export const StatusMessage = ({ message }: { message: string }) => {
       >
         {message}
       </Typography>
-      <CuCircularProgress color={'primary'} />
     </ListStack>
   )
 }


### PR DESCRIPTION
팀 게시판 페이지의 튜토리얼 버튼 위치를 변경했습니다

기존

<img width="415" alt="Screen_Shot 2024-02-05 14 10 42" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/65eee7aa-9482-4361-8ba1-9c036603ac6f">


바뀐 위치

<img width="415" alt="Screen_Shot 2024-02-05 14 40 49" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0cf69426-e595-4fd5-98eb-5180a2a04c9b">


(+ 추가로 추가했던 로딩 컴포넌트를 제거하고 기존 디자인으로 (스피너 대신 메시지로) 다시 적용했습니다.)

- close #665