### PR TITLE
[HOTFIX] 링크 모음, 링크 버튼, 쇼케이스 댓글 문제 해결

### DIFF
--- a/src/app/recruit/[id]/panel/LinkButton.tsx
+++ b/src/app/recruit/[id]/panel/LinkButton.tsx
@@ -24,10 +24,22 @@ const LinkButton = ({
   href: string
   variant: 'text' | 'outlined' | 'contained'
 }) => {
+  const convertLink = (link: string) => {
+    const httpPattern = /^https?:\/\//i
+    if (!httpPattern.test(link)) {
+      return `http://${link}`
+    }
+    return link
+  }
   //@todo 이동불가능한 url 처리
   return (
     <LinkTooltip placement="bottom-start" title={href}>
-      <Button variant={variant} href={href} sx={style.button} disabled={!href}>
+      <Button
+        variant={variant}
+        href={convertLink(href)}
+        sx={style.button}
+        disabled={!href}
+      >
         <InsertLinkOutlinedIcon />
       </Button>
     </LinkTooltip>

--- a/src/app/showcase/detail/[id]/page.tsx
+++ b/src/app/showcase/detail/[id]/page.tsx
@@ -6,15 +6,17 @@ import ShowcaseViewer from './panel/ShowcaseViewer'
 import { IShowcaseViewerFields } from '@/types/IShowcaseEdit'
 import CuCircularProgress from '@/components/CuCircularProgress'
 import useSWR from 'swr'
-import { defaultGetFetcher } from '@/api/fetchers'
+// import { defaultGetFetcher } from '@/api/fetchers'
 import CommentContainer from './panel/CommentContainer'
+import useAxiosWithAuth from '@/api/config'
 
 const ShowcaseDetailPage = ({ params }: { params: { id: number } }) => {
+  const axiosWithAuth = useAxiosWithAuth()
   const { data, isLoading, error } = useSWR<IShowcaseViewerFields>(
     `${process.env.NEXT_PUBLIC_API_URL}/api/v1/showcase/${params.id}`,
-    defaultGetFetcher,
-    { shouldRetryOnError: false },
+    (url: string) => axiosWithAuth.get(url).then((res) => res.data),
   )
+
   if (isLoading) return <CuCircularProgress color={'secondary'} />
   if (error) {
     if (error.response && error.response.status === 404) {

--- a/src/app/showcase/detail/[id]/panel/CommentContainer.style.ts
+++ b/src/app/showcase/detail/[id]/panel/CommentContainer.style.ts
@@ -16,6 +16,8 @@ export const commentListContainer = {
   height: 'auto',
   gap: '1rem',
   justifyContent: 'space-between',
+  overflowWrap: 'anywhere',
+  alignItems: 'center',
 }
 
 export const commenterInfo = {

--- a/src/app/showcase/detail/[id]/panel/CommentWriter.tsx
+++ b/src/app/showcase/detail/[id]/panel/CommentWriter.tsx
@@ -71,6 +71,7 @@ export const CommentWriter = ({
               onChange={onChangeContent}
               placeholder="댓글을 작성해주세요."
               style={style.writerInput}
+              inputProps={{ maxLength: 150 }}
             />
             <IconButton type="submit" style={style.writerButton}>
               <SendIcon />

--- a/src/app/showcase/panel/common/LinksViewer.tsx
+++ b/src/app/showcase/panel/common/LinksViewer.tsx
@@ -5,9 +5,12 @@ import { TagIcon } from '@/icons'
 import * as Style from './SkillInput.style'
 
 interface IlinksProps {
-  links: string[] | undefined
+  links: ILink[] | undefined
 }
-
+interface ILink {
+  link: string
+  name: string
+}
 const LinksViewer = ({ links }: IlinksProps) => {
   const convertLink = (link: string) => {
     const httpPattern = /^https?:\/\//i
@@ -34,10 +37,11 @@ const LinksViewer = ({ links }: IlinksProps) => {
         />
       </Stack>
       <Stack>
-        {links?.map((link: any) => {
+        {links?.map((link: ILink) => {
           return (
             <>
               <Typography
+                key={crypto.randomUUID()}
                 component="a"
                 color={'text.normal'}
                 variant="Body2"


### PR DESCRIPTION
### 수정사항
- 링크 버튼을 누르면 상대경로로 넘어가던 현상을 수정했습니다.
**Before**
![Screen Recording 2024-02-05 at 3 41 17 PM](https://github.com/peer-42seoul/Peer-Frontend/assets/62472550/1d8cb012-9e2f-413b-807b-41c09b7073be)
**After**

![Screen Recording 2024-02-05 at 3 41 45 PM](https://github.com/peer-42seoul/Peer-Frontend/assets/62472550/6e681ceb-0e75-46bb-ba98-e99c93609faf)

- 링크 모음에서 key값이 없던 상태를 보완하였습니다.
```javascript
{links?.map((link: ILink) => {
          return (
            <>
              <Typography
                key={crypto.randomUUID()} // 랜덤으로 키값 추가
                component="a"
                color={'text.normal'}
                variant="Body2"
))}
```

- 쇼케이스 디테일 페이지 내에서 수정 버튼의 권한을 받아올 수 있도록 api를 토큰과 함께 호출합니다.
- 쇼케이스 디테일 페이지 내에서 댓글 입력 제한을 최대 한글 150자로 입력받습니다.
- 쇼케이스 디테일 페이지 내 댓글에서 스타일 수정이 있었습니다.
