### PR TITLE
[HOTFIX] 팀 게시판 접근 불가 문제 해결

### DIFF
--- a/src/app/teams/[id]/board/@list/page.tsx
+++ b/src/app/teams/[id]/board/@list/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import { AxiosResponse, isAxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { Box, Stack } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
 import {
   ListPageContainer,
@@ -34,9 +34,9 @@ const TeamBoard = ({ params }: { params: { id: string } }) => {
           `/api/v1/team-page/simple/${teamId}`,
         )
         setBoardList(res.data)
-        if (!res.data || res.data.length == 0)
-          throw new Error('팀 페이지가 존재하지 않습니다.')
-        setBoard('LIST', res.data[0].boardId)
+        if (!res.data) throw new Error('팀 페이지가 존재하지 않습니다.')
+        if (res.data.length === 0) setBoard('LIST', undefined)
+        else setBoard('LIST', res.data[0].boardId)
       } catch (err: unknown) {
         if (isAxiosError(err) && err.response?.status === 403) {
           alert('팀 페이지에 접근할 권한이 없습니다.')
@@ -52,7 +52,7 @@ const TeamBoard = ({ params }: { params: { id: string } }) => {
 
   return (
     <ListPageContainer>
-      {boardList && boardList.length > 0 && boardId && (
+      {boardList && (
         <>
           <TopPageButton>
             <CuButton
@@ -68,30 +68,43 @@ const TeamBoard = ({ params }: { params: { id: string } }) => {
             />
           </TopPageButton>
           <ListBoxContainer>
-            <Stack
-              direction={'row'}
-              alignItems={'center'}
-              justifyContent={'space-between'}
-            >
-              <Box>
-                <BoardDropdown boardData={boardList} />
-                <Tutorial content={<TeamBoardTutorial />} />
-              </Box>
-              <Stack direction={'row'} spacing={'0.5rem'}>
-                <IconButtonContainer
-                  setKeyword={setKeyword}
-                  onClickPlus={() => {
-                    setBoard('EDIT', boardId)
-                  }}
-                />
-                <NewPostButton
-                  onClick={() => {
-                    setBoard('EDIT', boardId)
-                  }}
-                />
-              </Stack>
-            </Stack>
-            <BoardPostList boardId={boardId} keyword={keyword} />
+            {boardList.length > 0 && boardId ? (
+              <>
+                <Stack
+                  direction={'row'}
+                  alignItems={'center'}
+                  justifyContent={'space-between'}
+                >
+                  <Box>
+                    <BoardDropdown boardData={boardList} />
+                    <Tutorial content={<TeamBoardTutorial />} />
+                  </Box>
+                  <Stack direction={'row'} spacing={'0.5rem'}>
+                    <IconButtonContainer
+                      setKeyword={setKeyword}
+                      onClickPlus={() => {
+                        setBoard('EDIT', boardId)
+                      }}
+                    />
+                    <NewPostButton
+                      onClick={() => {
+                        setBoard('EDIT', boardId)
+                      }}
+                    />
+                  </Stack>
+                </Stack>
+                <BoardPostList boardId={boardId} keyword={keyword} />
+              </>
+            ) : (
+              <Typography
+                variant="Body1"
+                color={'text.alternative'}
+                textAlign={'center'}
+              >
+                게시판이 존재하지 않습니다. 게시판 관리에서 게시판을
+                생성해보세요!
+              </Typography>
+            )}
           </ListBoxContainer>
         </>
       )}

--- a/src/app/teams/[id]/board/@setting/page.tsx
+++ b/src/app/teams/[id]/board/@setting/page.tsx
@@ -8,6 +8,7 @@ import BackgroundBox from '@/components/BackgroundBox'
 import CuButton from '@/components/CuButton'
 import useMedia from '@/hook/useMedia'
 import useToast from '@/states/useToast'
+import useTeamPageState from '@/states/useTeamPageState'
 import { ITeamBoard } from '@/types/TeamBoardTypes'
 import BoardItem from './panel/BoardItem'
 import * as style from './page.style'
@@ -42,6 +43,7 @@ const TeamBoardSetting = ({ params }: { params: { id: string } }) => {
   const { isPc } = useMedia()
   const axiosWithAuth = useAxiosWithAuth()
   const { openToast } = useToast()
+  const { resetState } = useTeamPageState()
 
   const { data, isLoading, error } = useSWR<ITeamBoard[]>(
     `/api/v1/team-page/simple/${teamId}`,
@@ -88,6 +90,12 @@ const TeamBoardSetting = ({ params }: { params: { id: string } }) => {
       })
   }
 
+  if (!data || isLoading || error) {
+    alert('게시판 목록을 불러오지 못했습니다.')
+    resetState()
+    return null
+  }
+
   // 모바일에서는 게시판 관리가 불가능합니다.
   if (!isPc)
     return (
@@ -97,42 +105,59 @@ const TeamBoardSetting = ({ params }: { params: { id: string } }) => {
         </Typography>
       </BackgroundBox>
     )
-  // TODO : 좀 더 구체적인 에러처리
-  if (!data || isLoading || error) return null
 
   return (
-    <BackgroundBox pcSx={{ padding: '1.5rem' }}>
-      <Stack spacing={'2rem'}>
-        <TitleStack title="게시판 추가">
-          <Stack
-            direction={'row'}
-            spacing={'0.38rem'}
-            sx={style.inputContainer}
+    <Stack
+      sx={{
+        boxSizing: 'border-box',
+        width: '100%',
+        padding: '2rem',
+      }}
+      spacing={'2rem'}
+    >
+      <CuButton
+        variant={'text'}
+        message={'게시판으로 돌아가기'}
+        TypographyProps={{
+          variant: 'CaptionEmphasis',
+          color: 'text.alternative',
+        }}
+        action={resetState}
+        style={{ width: 'fit-content' }}
+      />
+      <BackgroundBox pcSx={{ padding: '1.5rem' }}>
+        <Stack spacing={'2rem'}>
+          <TitleStack title="게시판 추가">
+            <Stack
+              direction={'row'}
+              spacing={'0.38rem'}
+              sx={style.inputContainer}
+            >
+              <TextField
+                inputRef={textFieldRef}
+                name={'new-board-name'}
+                sx={{ flexGrow: 1 }}
+              />
+              <CuButton
+                variant={'text'}
+                action={handleCreateBoard}
+                message="추가"
+              />
+            </Stack>
+          </TitleStack>
+          <TitleStack
+            title={'게시판 목록'}
+            warning={'게시판 삭제시 내부 모든 글이 삭제되고 복구할 수 없어요.'}
           >
-            <TextField
-              inputRef={textFieldRef}
-              name={'new-board-name'}
-              sx={{ flexGrow: 1 }}
-            />
-            <CuButton
-              variant={'text'}
-              action={handleCreateBoard}
-              message="추가"
-            />
-          </Stack>
-        </TitleStack>
-        <TitleStack
-          title={'게시판 목록'}
-          warning={'게시판 삭제시 내부 모든 글이 삭제되고 복구할 수 없어요.'}
-        >
-          <Stack>
-            {data.map((board: ITeamBoard) => (
-              <BoardItem key={crypto.randomUUID()} board={board} />
-            ))}
-          </Stack>
-        </TitleStack>
-      </Stack>
-    </BackgroundBox>
+            <Stack>
+              {data.map((board: ITeamBoard) => (
+                <BoardItem key={crypto.randomUUID()} board={board} />
+              ))}
+            </Stack>
+          </TitleStack>
+        </Stack>
+      </BackgroundBox>
+    </Stack>
   )
 }
 

--- a/src/components/board/EditPanel.tsx
+++ b/src/components/board/EditPanel.tsx
@@ -39,7 +39,7 @@ export const EditPage = ({ title, children, handleGoBack }: IEditPageProps) => {
   const { isPc } = useMedia()
   if (isPc)
     return (
-      <Stack spacing={'1.5rem'}>
+      <Stack spacing={'1.5rem'} width={'100%'}>
         <Typography variant="Body2Emphasis" color="text.strong">
           {title}
         </Typography>

--- a/src/states/useTeamPageState.ts
+++ b/src/states/useTeamPageState.ts
@@ -21,15 +21,13 @@ interface ITeamPageState {
   postId: number | undefined
   resetState: () => void
   setNotice: (boardType: TboardType, postId?: number) => void
-  setBoard: (boardType: TboardType, boardId: number, postId?: number) => void
+  setBoard: (boardType: TboardType, boardId?: number, postId?: number) => void
 }
 
 const useTeamPageState = create<ITeamPageState>((set) => ({
   layout: 'SIDEBAR',
-  // boardType: 'NOTICE',
   boardType: 'LIST',
-  // boardId: undefined,
-  boardId: 1,
+  boardId: undefined,
   postId: undefined,
   resetState: () =>
     set({


### PR DESCRIPTION
### 관련 이슈

- #695

### 작업 내용

#### 팀 게시판 접근 불가 문제

팀을 새로 생성했을 때 기본적으로 생성되는 게시판이 없어 발생하는 문제였습니다.
기존에는 게시판 데이터가 없을 경우에 에러를 반환하게 했는데, 게시판 생성 안내 메시지를 띄우는 식으로 변경했습니다.

<img width="676" alt="Screen_Shot 2024-02-05 18 46 11" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/75571fc5-5f3e-49eb-90d3-3419de2abdec">

#### EditPage 스타일 조정

배경 너비가 내부 컴포넌트 너비보다 작아지는 문제가 있어 `width: 100%` 을 추가했습니다.

#### 게시판으로 돌아가기 버튼 추가

게시판 관리 페이지에서 다시 게시판 목록으로 돌아갈 수 있는 버튼을 추가했습니다.

<img width="676" alt="Screen_Shot 2024-02-05 18 46 43" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/b62413e1-f0a2-4bca-83a3-efe7f7358d97">
