### PR TITLE
Style: 피어로그 button disabled, beta badge 추가

### DIFF
--- a/src/app/teams/[id]/panel/NavBar.tsx
+++ b/src/app/teams/[id]/panel/NavBar.tsx
@@ -55,7 +55,8 @@ const TeamSidebar = ({ id }: { id: string }) => {
           onClick: () => router.push(`/teams/${id}/peerlog`),
           value: 'peerlog',
           icon: <PeerlogIcon sx={style.peerlog} />,
-          new: true,
+          isBeta: true,
+          disabled: true,
         },
         {
           label: '쇼케이스',
@@ -63,7 +64,6 @@ const TeamSidebar = ({ id }: { id: string }) => {
           value: 'showcase',
           icon: <ShowcaseIcon sx={style.showcase} />,
           new: true,
-          // disabled: true,
         },
       ]}
     />

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -101,7 +101,7 @@ export const newTextBadge = {
 
 const BADGE_TRANSLATE = 'translate(130%, -50%)'
 
-export const newBadge = {
+export const badgeBase = {
   '& .MuiBadge-badge': {
     width: '3px',
     minWidth: '3px', // mui 기본 설정 디자인 오버라이딩
@@ -118,5 +118,17 @@ export const newBadge = {
       msTransform: `scale(0) ${BADGE_TRANSLATE}`,
       MozTransform: `scale(0) ${BADGE_TRANSLATE}`,
     },
+  },
+}
+
+export const newBadge = {
+  '& .MuiBadge-badge': {
+    backgroundColor: (theme: Theme) => theme.palette.yellow.strong,
+  },
+}
+
+export const betaBadge = {
+  '& .MuiBadge-badge': {
+    backgroundColor: (theme: Theme) => theme.palette.red.strong,
   },
 }

--- a/src/components/CuNavBar.tsx
+++ b/src/components/CuNavBar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material'
 import useMedia from '@/hook/useMedia'
 import { ChevronLeft } from '@/icons'
+import { BetaIcon } from '@/components/BetaBadge'
 import * as style from './CuNavBar.style'
 
 interface ITabInfo {
@@ -21,6 +22,7 @@ interface ITabInfo {
   icon: ReactElement
   disabled?: boolean
   new?: boolean
+  isBeta?: boolean
 }
 
 interface ICuNavBarProps {
@@ -113,7 +115,7 @@ const PcToggleButton = ({
       onClick={tab.onClick}
       sx={{
         ...style.pcTab,
-        ...(isNewTab ? style.newTab : undefined),
+        ...(isNewTab || tab.isBeta ? style.newTab : undefined),
       }}
       disabled={tab.disabled}
       selected={selected}
@@ -130,6 +132,7 @@ const PcToggleButton = ({
             NEW
           </Typography>
         )}
+        {tab.isBeta && <BetaIcon sx={{ paddingLeft: '0.5rem' }} />}
       </Stack>
     </ToggleButton>
   )
@@ -153,7 +156,11 @@ const MobileToggleButton = ({
       selected={selected}
     >
       <Stack direction={'column'} spacing={'0.12rem'} alignItems={'center'}>
-        <Badge sx={style.newBadge} variant={'dot'} invisible={!isNewTab}>
+        <Badge
+          sx={isNewTab ? style.newBadge : style.betaBadge}
+          variant={'dot'}
+          invisible={!isNewTab && !tab.isBeta}
+        >
           <Box sx={style.iconBoxBase}>{tab.icon}</Box>
         </Badge>
         <Typography variant={'Tag'}>{tab.mobileLabel ?? tab.label}</Typography>


### PR DESCRIPTION
### 관련 이슈

- #697

### 작업 내용

피어로그 메뉴에 접근 시에 404 페이지가 뜨는 문제를 수정했습니다.
- 피어로그 메뉴 disabled
- 베타 아이콘 추가

<img width="20%" alt="Screen_Shot 2024-02-05 19 20 30" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0f7ebc8a-b3f5-43dc-a05d-5d7888661683">
<img width="40%" alt="Screen_Shot 2024-02-05 19 20 53" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/5e35b029-677b-40c1-b77d-10e3ed9eb9a9">
