### PR TITLE
[C-MAIN] 메인페이지와 배너에 여백 생기도록

### DIFF
--- a/src/app/panel/MainPage.tsx
+++ b/src/app/panel/MainPage.tsx
@@ -324,7 +324,7 @@ const MainPage = ({ initData }: { initData: IPagination<IPost[]> }) => {
 
       {/* pc view */}
       <div className="pc-layout">
-        <Container disableGutters sx={containerStyle}>
+        <Container sx={containerStyle}>
           <Stack direction={'row'} spacing={4}>
             <Stack flex={1} gap={'0.5rem'}>
               {keyword === '' ? (

--- a/src/app/panel/layout-panel/Nav.style.ts
+++ b/src/app/panel/layout-panel/Nav.style.ts
@@ -1,4 +1,5 @@
 export const navContainerStyle = {
+  display: 'flex',
   position: 'fixed',
   left: 0,
   right: 0,
@@ -6,7 +7,7 @@ export const navContainerStyle = {
   overflow: 'hidden',
   zIndex: 1300,
   backgroundColor: 'background.primary',
-  flexDirection: 'row',
+  flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
   width: '100%',

--- a/src/app/panel/layout-panel/PcNav.tsx
+++ b/src/app/panel/layout-panel/PcNav.tsx
@@ -7,6 +7,7 @@ import {
   BottomNavigation,
   BottomNavigationAction,
   Button,
+  Container,
   IconButton,
   Stack,
   Typography,
@@ -54,7 +55,7 @@ const PcNav = () => {
   }, [pathname])
 
   return (
-    <Stack sx={navContainerStyle}>
+    <Container sx={navContainerStyle}>
       <Stack
         direction={'row'}
         maxWidth={1280}
@@ -201,7 +202,7 @@ const PcNav = () => {
           </Link>
         </Stack>
       </Stack>
-    </Stack>
+    </Container>
   )
 }
 


### PR DESCRIPTION
[![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/67393169-e431-4705-a289-ed9a1aca08df)](https://github.com/peer-42seoul/Peer-Frontend/issues/710)
* 메인페이지와 배너에 좌우 여백 추가했습니다.
https://github.com/peer-42seoul/Peer-Frontend/issues/710