### PR TITLE
[HOTFIX] 팀페이지 쇼케이스 페이지 탭 메뉴 오류 수정

### DIFF
--- a/src/app/teams/[id]/panel/NavBar.tsx
+++ b/src/app/teams/[id]/panel/NavBar.tsx
@@ -16,6 +16,8 @@ const getTabValue = (path: string) => {
   if (path.includes('/notice')) return 'notice'
   else if (path.includes('/board')) return 'board'
   else if (path.includes('/setting')) return 'setting'
+  else if (path.includes('/peerlog')) return 'peerlog'
+  else if (path.includes('/showcase')) return 'showcase'
   else return 'main'
 }
 


### PR DESCRIPTION
### 관련 이슈

- close #739

### 작업 내용

탭 활성화 여부를 결정하는 함수에 peerlog, showcase path를 확인하는 로직이 빠져 있어서 탭 메뉴가 메인으로 돌아가는 것이었습니다.
peerlog, showcase도 확인하도록 수정했습니다

![Screen_Shot 2024-02-06 12 41 34](https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/67f5b618-356d-4f01-8e0c-435ac06a4e9c)


