### PR TITLE
[HOTFIX] 팀 게시판 댓글 글자수 에러 처리 누락

### DIFF
--- a/src/components/board/CommentPanel.tsx
+++ b/src/components/board/CommentPanel.tsx
@@ -254,6 +254,7 @@ export const CommentFormContainer = ({
           fullWidth
           name={'new-content'}
           id={'new-content'}
+          inputProps={{ maxLength: 150 }}
         />
         <IconButton sx={style.IconButton} disabled={isLoading} type={'submit'}>
           <SendIcon sx={style.SendIcon} />


### PR DESCRIPTION
### 관련 이슈

- close #748

### 작업 내용

댓글 길이 제한을 프론트에서는 처리하지 않아서 댓글이 길 경우 단순 에러 메시지를 띄우고 있었습니다.
쇼케이스 댓글에서 처리된 것 처럼 150글자 제한을 추가했습니다.