### PR TITLE
[HOTFIX] 쪽지와 팀 게시판 디자인 수정

### DIFF
--- a/src/app/my-page/message/@detail/panel/MessageContainer.style.ts
+++ b/src/app/my-page/message/@detail/panel/MessageContainer.style.ts
@@ -7,7 +7,9 @@ export const pcBox = {
 
 export const pcMessageContainer = {
   // 메시지 컨테이너
-  width: '49.8rem',
+  boxSizing: 'border-box',
+  width: '100%',
+  // width: '49.8rem',
   height: '48.6rem',
   padding: '2rem 1.5rem 3rem 1.5rem',
   backgroundColor: (theme: Theme) => theme.palette.background.primary,

--- a/src/components/board/ListPanel.style.ts
+++ b/src/components/board/ListPanel.style.ts
@@ -15,8 +15,7 @@ export const ListBoxContainer = {
   background: (theme: Theme) => theme.palette.background.secondary,
 }
 
-export const PcListStack = {
-  // 페이징 방식이 페이지네이션이 될 경우 수정될 수 있음
+export const ListStack = {
   height: '100%',
   overflowY: 'scroll',
 }

--- a/src/components/board/ListPanel.tsx
+++ b/src/components/board/ListPanel.tsx
@@ -168,9 +168,8 @@ export const ListBoxContainer = ({ children }: IChildrenProps) => {
 }
 
 export const ListStack = ({ children }: IChildrenProps) => {
-  const { isPc } = useMedia()
   return (
-    <Stack sx={isPc ? style.PcListStack : undefined} spacing={'1rem'}>
+    <Stack sx={style.ListStack} spacing={'1rem'}>
       {children}
     </Stack>
   )


### PR DESCRIPTION
### 관련 이슈

- close #740
- close #758

### 작업 내용

#### 쪽지 상세 페이지 태블릿 크기 화면에서 레이아웃 깨짐 현상

컨테이너 pc 사이즈에서 컨테이너 너비를 지정한 경우에 body를 넘어가는 문제가 있어서 너비를 100%으로 설정했습니다.
다만 이렇게 수정한 경우에 레이아웃이 깨지지는 않지만

<img width="300" alt="Screen_Shot 2024-02-06 14 06 58" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/ee5e6cbe-c626-468d-abc2-f4d2f8056fd2">

이처럼 날짜 표시 부분이 의도한 바와 다르게 찌그러지는 현상이 있어서 일단 너비를 설정한 부분은 주석으로 남겨두었습니다.
추후 태블릿 사이즈 브레이크 포인트를 지정해서 너비를 3단계 정도로 조정해봐야 할 것 같습니다.

#### 게시판 모바일 목록 스크롤 안됨

PC 사이즈일때만 스크롤이 되게 하고 모바일인 경우에는 스크롤 설정을 하지 않았더라고요,,,
화면 너비 상관 없이 스크롤 적용할 수 있도록 수정했습니다.
