### PR TITLE
[HOTFIX] 팀 페이지 관련 버그 핫픽스

### DIFF
--- a/src/app/teams/[id]/board/@setting/page.tsx
+++ b/src/app/teams/[id]/board/@setting/page.tsx
@@ -83,17 +83,37 @@ const TeamBoardSetting = ({ params }: { params: { id: string } }) => {
               severity: 'error',
               message: '이미 존재하는 게시판 이름입니다.',
             })
-            return
+          } else if (e.response?.status === 403) {
+            openToast({
+              severity: 'error',
+              message: '게시판 추가는 팀 리더만 가능합니다.',
+            })
+          } else {
+            openToast({
+              severity: 'error',
+              message: '게시판을 추가하지 못했습니다.',
+            })
           }
+        } else {
+          openToast({
+            severity: 'error',
+            message: '게시판을 추가하지 못했습니다.',
+          })
         }
-        openToast({
-          severity: 'error',
-          message: '게시판을 추가하지 못했습니다.',
-        })
       })
   }
 
-  if (!data || error) {
+  if (error) {
+    if (isAxiosError(error) && error.response?.status === 403) {
+      alert('게시판 관리는 팀 리더만 가능합니다')
+    } else {
+      alert('게시판 목록을 불러오지 못했습니다.')
+    }
+    resetState()
+    return null
+  }
+
+  if (!isLoading && !data) {
     alert('게시판 목록을 불러오지 못했습니다.')
     resetState()
     return null
@@ -158,7 +178,7 @@ const TeamBoardSetting = ({ params }: { params: { id: string } }) => {
               }
             >
               <Stack>
-                {data.map((board: ITeamBoard) => (
+                {data?.map((board: ITeamBoard) => (
                   <BoardItem
                     key={crypto.randomUUID()}
                     board={board}

--- a/src/app/teams/[id]/board/@setting/panel/BoardItem.tsx
+++ b/src/app/teams/[id]/board/@setting/panel/BoardItem.tsx
@@ -1,4 +1,5 @@
 import { useSWRConfig } from 'swr'
+import { isAxiosError } from 'axios'
 import useAxiosWithAuth from '@/api/config'
 import { ITeamBoard } from '@/types/TeamBoardTypes'
 import { IconButton, Stack, Typography } from '@mui/material'
@@ -29,11 +30,25 @@ const BoardItem = ({
         })
         mutate(`/api/v1/team-page/simple/${teamId}`)
       })
-      .catch(() => {
-        openToast({
-          severity: 'error',
-          message: '게시판을 삭제하지 못했습니다.',
-        })
+      .catch((e: unknown) => {
+        if (isAxiosError(e)) {
+          if (e.response?.status === 403) {
+            openToast({
+              severity: 'error',
+              message: '게시판 추가는 팀 리더만 가능합니다.',
+            })
+          } else {
+            openToast({
+              severity: 'error',
+              message: '게시판을 추가하지 못했습니다.',
+            })
+          }
+        } else {
+          openToast({
+            severity: 'error',
+            message: '게시판을 추가하지 못했습니다.',
+          })
+        }
       })
   }
   return (

--- a/src/app/teams/[id]/notice/@edit/panel/NoticeEditForm.tsx
+++ b/src/app/teams/[id]/notice/@edit/panel/NoticeEditForm.tsx
@@ -36,7 +36,7 @@ const NoticeEditForm = ({
           })
         })
         .catch(() => {
-          alert('게시글을 불러오는데 실패했습니다.')
+          alert('글을 불러오는데 실패했습니다.')
           setNotice('LIST')
         })
         .finally(() => {

--- a/src/app/teams/[id]/notice/@edit/panel/NoticeEditForm.tsx
+++ b/src/app/teams/[id]/notice/@edit/panel/NoticeEditForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { FormEvent, useEffect, useRef, useState } from 'react'
+import { isAxiosError } from 'axios'
 import { Editor } from '@toast-ui/editor'
 import useAxiosWithAuth from '@/api/config'
 import useTeamPageState from '@/states/useTeamPageState'
@@ -67,11 +68,18 @@ const NoticeEditForm = ({
           alert('공지사항을 수정했습니다.')
           setNotice('DETAIL', postId)
         })
-        .catch(() => {
-          openToast({
-            severity: 'error',
-            message: '공지사항 수정에 실패했습니다.',
-          })
+        .catch((e: unknown) => {
+          if (isAxiosError(e) && e.response?.status === 403) {
+            openToast({
+              severity: 'error',
+              message: '공지사항 수정은 팀 리더와 작성자만 가능합니다.',
+            })
+          } else {
+            openToast({
+              severity: 'error',
+              message: '공지사항 수정에 실패했습니다.',
+            })
+          }
         })
     } else {
       // 글 작성
@@ -84,11 +92,18 @@ const NoticeEditForm = ({
           alert('공지사항이 등록되었습니다.')
           setNotice('DETAIL', res.data.postId)
         })
-        .catch(() => {
-          openToast({
-            severity: 'error',
-            message: '공지사항 수정에 실패했습니다.',
-          })
+        .catch((e: unknown) => {
+          if (isAxiosError(e) && e.response?.status === 403) {
+            openToast({
+              severity: 'error',
+              message: '공지사항 등록은 팀 리더와 작성자만 가능합니다.',
+            })
+          } else {
+            openToast({
+              severity: 'error',
+              message: '공지사항 등록에 실패했습니다.',
+            })
+          }
         })
     }
   }

--- a/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
+++ b/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
@@ -31,6 +31,8 @@ const NoticeList = ({
     if (!isLoading && size !== 1) setSize(1)
   }, [keyword])
 
+  const isEmpty = !data || data.length === 0 || data[0].content.length === 0
+
   if (error) {
     if (error.status === 403) {
       alert('팀 페이지에 접근할 권한이 없습니다.')
@@ -51,25 +53,29 @@ const NoticeList = ({
 
   return (
     <ListStack>
-      {data?.map((page, index) => {
-        return (
-          <Fragment key={index}>
-            {page.content.map((notice: ITeamNotice) => {
-              return (
-                <ListItem
-                  key={notice.postId}
-                  title={notice.title}
-                  authorNickname={notice.nickname}
-                  createdAt={notice.createdAt}
-                  onClick={() => {
-                    setNotice('DETAIL', notice.postId)
-                  }}
-                />
-              )
-            })}
-          </Fragment>
-        )
-      })}
+      {isEmpty ? (
+        <StatusMessage message="등록된 공지사항이 없습니다. 팀 리더라면 새로운 공지사항을 작성해보세요!" />
+      ) : (
+        data?.map((page, index) => {
+          return (
+            <Fragment key={index}>
+              {page.content.map((notice: ITeamNotice) => {
+                return (
+                  <ListItem
+                    key={notice.postId}
+                    title={notice.title}
+                    authorNickname={notice.nickname}
+                    createdAt={notice.createdAt}
+                    onClick={() => {
+                      setNotice('DETAIL', notice.postId)
+                    }}
+                  />
+                )
+              })}
+            </Fragment>
+          )
+        })
+      )}
       <Box ref={targetRef}>{isLoading && '로딩중입니다...'}</Box>
     </ListStack>
   )

--- a/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
+++ b/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios'
 import { Fragment, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box } from '@mui/material'
@@ -34,7 +35,7 @@ const NoticeList = ({
   const isEmpty = !data || data.length === 0 || data[0].content.length === 0
 
   if (error) {
-    if (error.status === 403) {
+    if (isAxiosError(error) && error.response?.status === 403) {
       alert('팀 페이지에 접근할 권한이 없습니다.')
     } else {
       alert('팀 페이지에 접근할 수 없습니다.')

--- a/src/app/teams/[id]/panel/TeamInfoContainer.tsx
+++ b/src/app/teams/[id]/panel/TeamInfoContainer.tsx
@@ -9,6 +9,7 @@ import useHeaderStore from '@/states/useHeaderStore'
 import { ITeamInfo } from '@/types/ITeamInfo'
 import { StatusIcon, IconInfo } from './TeamInfoComponent'
 import * as style from './TeamInfoContainer.style'
+import { isAxiosError } from 'axios'
 
 const TeamInfoContainer = ({ id }: { id: number }) => {
   const axiosInstance = useAxiosWithAuth()
@@ -30,8 +31,10 @@ const TeamInfoContainer = ({ id }: { id: number }) => {
   }, [data])
 
   if (error) {
-    if (error.status === 403) alert('팀 페이지에 접근할 권한이 없습니다.')
-    else if (error.status === 404) alert('팀 페이지가 존재하지 않습니다.')
+    if (isAxiosError(error) && error.response?.status === 403)
+      alert('팀 페이지에 접근할 권한이 없습니다.')
+    else if (isAxiosError(error) && error.response?.status === 404)
+      alert('팀 페이지가 존재하지 않습니다.')
     else alert('팀 페이지에 접근할 수 없습니다.')
     router.push('/team-list')
     return <CuCircularProgress color={'primary'} />

--- a/src/app/teams/[id]/setting/page.tsx
+++ b/src/app/teams/[id]/setting/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { isAxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
 import { Button, Card, Stack, Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
@@ -52,7 +53,7 @@ const TeamsSetupPage = ({ params }: { params: { id: string } }) => {
   }, [])
 
   if (error) {
-    if (error.status === 403) {
+    if (isAxiosError(error) && error.response?.status === 403) {
       alert('팀 설정은 팀 리더만 가능합니다.')
     } else {
       alert('팀 페이지에 접근할 수 없습니다.')

--- a/src/app/teams/[id]/setting/page.tsx
+++ b/src/app/teams/[id]/setting/page.tsx
@@ -53,7 +53,7 @@ const TeamsSetupPage = ({ params }: { params: { id: string } }) => {
 
   if (error) {
     if (error.status === 403) {
-      alert('팀 페이지에 접근할 권한이 없습니다.')
+      alert('팀 설정은 팀 리더만 가능합니다.')
     } else {
       alert('팀 페이지에 접근할 수 없습니다.')
     }


### PR DESCRIPTION
#### 작업 내용

- 팀 페이지 권한 오류 alert 에러처리 로직이 status code를 확인하지 못하고 있어서 그 부분을 추가했습니다
- 빈 공지사항의 경우 안내 메시지를 추가했습니다.
- 팀 설정 페이지에서 데이터가 비어있던 경우 우선적으로 로드를 못하도록 처리되고 있었습니다. 로딩이 완료되었음에도 빈 데이터인 경우에 에러를 보이도록 수정했습니다.
- 공지사항 작성 권한이 처리되어 있지 않던 문제가 있어서 리더인 경우에만 작성 가능하다는 안내 toast를 추가했습니다.

#### 관련 이슈

- #766 
- #768 
- #769 
- #770 