### PR TITLE
[HOTFIX] 빈 공지사항 안내 문구 구조 수정

### DIFF
--- a/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
+++ b/src/app/teams/[id]/notice/@list/panel/NoticeList.tsx
@@ -52,31 +52,32 @@ const NoticeList = ({
 
   if (isLoading) return <StatusMessage message="로딩중입니다..." />
 
+  if (isEmpty)
+    return (
+      <StatusMessage message="등록된 공지사항이 없습니다. 팀 리더라면 새로운 공지사항을 작성해보세요!" />
+    )
+
   return (
     <ListStack>
-      {isEmpty ? (
-        <StatusMessage message="등록된 공지사항이 없습니다. 팀 리더라면 새로운 공지사항을 작성해보세요!" />
-      ) : (
-        data?.map((page, index) => {
-          return (
-            <Fragment key={index}>
-              {page.content.map((notice: ITeamNotice) => {
-                return (
-                  <ListItem
-                    key={notice.postId}
-                    title={notice.title}
-                    authorNickname={notice.nickname}
-                    createdAt={notice.createdAt}
-                    onClick={() => {
-                      setNotice('DETAIL', notice.postId)
-                    }}
-                  />
-                )
-              })}
-            </Fragment>
-          )
-        })
-      )}
+      {data?.map((page, index) => {
+        return (
+          <Fragment key={index}>
+            {page.content.map((notice: ITeamNotice) => {
+              return (
+                <ListItem
+                  key={notice.postId}
+                  title={notice.title}
+                  authorNickname={notice.nickname}
+                  createdAt={notice.createdAt}
+                  onClick={() => {
+                    setNotice('DETAIL', notice.postId)
+                  }}
+                />
+              )
+            })}
+          </Fragment>
+        )
+      })}
       <Box ref={targetRef}>{isLoading && '로딩중입니다...'}</Box>
     </ListStack>
   )


### PR DESCRIPTION
아래 발견된 의문의 컴포넌트 제거 겸 데이터가 빈 경우에도 무한스크롤 감지 객체가 보이도록 구조가 짜여 있어서 수정했습니다.

![image](https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0d0bb1f0-d535-4567-b454-16af6fc407a9)
