### PR TITLE
[Hotfix] 토스트 노티 메세지 지속시간 10초 에서 3초로 감소

### DIFF
--- a/src/states/useToast.ts
+++ b/src/states/useToast.ts
@@ -48,7 +48,7 @@ const useToast = create<IToastState>((set, get) => {
 
   const defaultToastProps: IToastProps = {
     open: false,
-    autoHideDuration: 10000,
+    autoHideDuration: 3000,
     onClose: closeToast,
     severity: undefined,
     message: '',
@@ -62,7 +62,7 @@ const useToast = create<IToastState>((set, get) => {
   return {
     toastProps: {
       open: false,
-      autoHideDuration: 10000,
+      autoHideDuration: 3000,
       onClose: closeToast,
       severity: undefined,
       message: '',


### PR DESCRIPTION
토스트 노티 메세지 지속시간 10초 에서 3초로 감소