### PR TITLE
[ADMIN] 어드민 공지/배너/태그 관리에서 삭제시 더블체크 모달 추가

### DIFF
--- a/src/app/admin/announce/Announce.tsx
+++ b/src/app/admin/announce/Announce.tsx
@@ -25,6 +25,8 @@ import DynamicToastEditor from '@/components/DynamicToastEditor'
 import { Editor } from '@toast-ui/editor'
 import DynamicToastViewer from '@/components/DynamicToastViewer'
 import { config } from '../panel/AdminAxios'
+import CuTextModal from '@/components/CuTextModal'
+import useModal from '@/hook/useModal'
 
 interface IAnnounceAllContent {
   announcementId: number
@@ -132,6 +134,13 @@ const Announce = () => {
   }
   // 백엔드 API에서는 page가 0부터 시작하므로 page - 1로 설정
 
+  const currentId = useRef<number>(-1)
+  const {
+    openModal: openRemoveModal,
+    closeModal: closeRemoveModal,
+    isOpen: isRemoveModalOpen,
+  } = useModal()
+
   const [currentNoticeStatus, setCurrentNoticeStatus] = useState('없음')
 
   // 초기 페이지 진입시 공지사항 목록 불러오기
@@ -211,7 +220,6 @@ const Announce = () => {
         announcementNoticeStatus: data.announcementNoticeStatus, // 'announcementStatus'를 'announcementNoticeStatus'로 매핑합니다.
         reservationDate:
           data.announcementNoticeStatus === '예약' ? DateFormed : null,
-        // content: data.content,
         content: editorRef.current ? editorRef.current.getMarkdown() : '',
       }
     } else return
@@ -226,7 +234,6 @@ const Announce = () => {
           .get(`${API_URL}/api/v1/admin/announcement`, {
             params,
             withCredentials: true,
-            // peer-test 도메인에서만 httpOnly sameSite 쿠키를 전달받을 수 있으므로 로컬에서 테스트 할 동안 임시로 주석처리
           })
           .then((res) => {
             totalPageVar.current = res.data.totalPages
@@ -354,6 +361,8 @@ const Announce = () => {
       })
       .then(() => {
         setOpen(false)
+        alert(announcementId + '번 공지가 삭제되었습니다.')
+        closeRemoveModal()
         axios
           .get(`${API_URL}/api/v1/admin/announcement`, {
             params,
@@ -669,7 +678,11 @@ const Announce = () => {
             {writeMode === 'view' ? (
               <Button
                 variant={'contained'}
-                onClick={() => onHandleDelete(getValues('announcementId'))}
+                // onClick={() => onHandleDelete(getValues('announcementId'))}
+                onClick={() => {
+                  currentId.current = getValues('announcementId')
+                  openRemoveModal()
+                }}
               >
                 삭제
               </Button>
@@ -691,6 +704,20 @@ const Announce = () => {
               </Button>
             )}
           </Stack>
+          <CuTextModal
+            title="태그 삭제하기"
+            open={isRemoveModalOpen}
+            onClose={closeRemoveModal}
+            content="정말 태그를 삭제하시겠습니까?"
+            textButton={{
+              text: '취소',
+              onClick: closeRemoveModal,
+            }}
+            containedButton={{
+              text: '삭제',
+              onClick: () => onHandleDelete(currentId.current),
+            }}
+          />
         </Container>
       </CuModal>
     </Container>

--- a/src/app/admin/announce/Announce.tsx
+++ b/src/app/admin/announce/Announce.tsx
@@ -27,6 +27,7 @@ import DynamicToastViewer from '@/components/DynamicToastViewer'
 import { config } from '../panel/AdminAxios'
 import CuTextModal from '@/components/CuTextModal'
 import useModal from '@/hook/useModal'
+import useToast from '@/states/useToast'
 
 interface IAnnounceAllContent {
   announcementId: number
@@ -134,6 +135,8 @@ const Announce = () => {
   }
   // 백엔드 API에서는 page가 0부터 시작하므로 page - 1로 설정
 
+  const { openToast } = useToast()
+
   const currentId = useRef<number>(-1)
   const {
     openModal: openRemoveModal,
@@ -229,6 +232,10 @@ const Announce = () => {
       })
       .then(() => {
         setOpen(false)
+        openToast({
+          message: '공지 글을 성공적으로 등록하였습니다.',
+          severity: 'success',
+        })
         reset()
         axios
           .get(`${API_URL}/api/v1/admin/announcement`, {
@@ -274,6 +281,10 @@ const Announce = () => {
     await axios
       .put(`${API_URL}/api/v1/admin/announcement`, submitData)
       .then(() => {
+        openToast({
+          message: '공지 글이 성공적으로 수정되었습니다.',
+          severity: 'success',
+        })
         setOpen(false)
         reset()
         axios
@@ -338,6 +349,10 @@ const Announce = () => {
       )
       .then(() => {
         setOpen(false)
+        openToast({
+          message: `공지글이 ${mode}처리 되었습니다.`,
+          severity: 'success',
+        })
         reset()
         axios
           .get(`${API_URL}/api/v1/admin/announcement`, {
@@ -361,7 +376,10 @@ const Announce = () => {
       })
       .then(() => {
         setOpen(false)
-        alert(announcementId + '번 공지가 삭제되었습니다.')
+        openToast({
+          message: `${announcementId}번 공지 글이 성공적으로 삭제되었습니다.`,
+          severity: 'success',
+        })
         closeRemoveModal()
         axios
           .get(`${API_URL}/api/v1/admin/announcement`, {

--- a/src/app/admin/announce/Announce.tsx
+++ b/src/app/admin/announce/Announce.tsx
@@ -372,6 +372,9 @@ const Announce = () => {
             setContent(res.data.content)
           })
       })
+      .catch((err) => {
+        alert('공지글 삭제 실패 \n 사유: ' + err)
+      })
   }
 
   return (

--- a/src/app/admin/announce/Announce.tsx
+++ b/src/app/admin/announce/Announce.tsx
@@ -522,8 +522,8 @@ const Announce = () => {
                 message: '글쓴이는 10자 이내로 입력해주세요.',
               },
             })}
-            error={!!errors.title}
-            helperText={errors.title?.message}
+            error={!!errors.writer}
+            helperText={errors.writer?.message}
             disabled={writeMode === 'view'}
           />
           {writeMode === 'view' ? (
@@ -678,7 +678,6 @@ const Announce = () => {
             {writeMode === 'view' ? (
               <Button
                 variant={'contained'}
-                // onClick={() => onHandleDelete(getValues('announcementId'))}
                 onClick={() => {
                   currentId.current = getValues('announcementId')
                   openRemoveModal()

--- a/src/app/admin/banner/Banner.tsx
+++ b/src/app/admin/banner/Banner.tsx
@@ -361,6 +361,8 @@ const Banner = () => {
           .then((res) => {
             setContent(res.data.content)
           })
+      }).catch((err) => {
+        alert('배너 삭제 실패 \n 사유: ' + err)
       })
   }
 

--- a/src/app/admin/banner/Banner.tsx
+++ b/src/app/admin/banner/Banner.tsx
@@ -21,6 +21,8 @@ import { DateTimePicker } from '@mui/x-date-pickers'
 import dayjs from 'dayjs'
 import CuModal from '@/components/CuModal'
 import { idStyle, statusStyle, titleStyle } from './BannerStyles'
+import CuTextModal from '@/components/CuTextModal'
+import useModal from '@/hook/useModal'
 
 interface IBannerAllContent {
   bannerId: number
@@ -120,6 +122,13 @@ const Banner = () => {
     size: 5,
   }
   // 백엔드 API에서는 page가 0부터 시작하므로 page - 1로 설정
+
+  const currentId = useRef<number>(-1)
+  const {
+    openModal: openRemoveModal,
+    closeModal: closeRemoveModal,
+    isOpen: isRemoveModalOpen,
+  } = useModal()
 
   const [currentReservationType, setCurrentReservationType] = useState('없음')
   const [currentBannerType, setCurrentBannerType] = useState('')
@@ -342,6 +351,8 @@ const Banner = () => {
       })
       .then(() => {
         setOpen(false)
+        alert(bannerId + '번 배너가 삭제되었습니다.')
+        closeRemoveModal()
         axios
           .get(`${API_URL}/api/v1/admin/banner`, {
             params,
@@ -658,7 +669,11 @@ const Banner = () => {
             {writeMode === 'view' ? (
               <Button
                 variant={'contained'}
-                onClick={() => onHandleDelete(getValues('bannerId'))}
+                // onClick={() => onHandleDelete(getValues('bannerId'))}
+                onClick={() => {
+                  currentId.current = getValues('bannerId')
+                  openRemoveModal()
+                }}
               >
                 삭제
               </Button>
@@ -680,6 +695,20 @@ const Banner = () => {
               </Button>
             )}
           </Stack>
+          <CuTextModal
+            title="태그 삭제하기"
+            open={isRemoveModalOpen}
+            onClose={closeRemoveModal}
+            content="정말 태그를 삭제하시겠습니까?"
+            textButton={{
+              text: '취소',
+              onClick: closeRemoveModal,
+            }}
+            containedButton={{
+              text: '삭제',
+              onClick: () => onHandleDelete(currentId.current),
+            }}
+          />
         </Container>
       </CuModal>
     </Container>

--- a/src/app/admin/banner/Banner.tsx
+++ b/src/app/admin/banner/Banner.tsx
@@ -23,6 +23,7 @@ import CuModal from '@/components/CuModal'
 import { idStyle, statusStyle, titleStyle } from './BannerStyles'
 import CuTextModal from '@/components/CuTextModal'
 import useModal from '@/hook/useModal'
+import useToast from '@/states/useToast'
 
 interface IBannerAllContent {
   bannerId: number
@@ -122,6 +123,8 @@ const Banner = () => {
     size: 5,
   }
   // 백엔드 API에서는 page가 0부터 시작하므로 page - 1로 설정
+
+  const { openToast } = useToast()
 
   const currentId = useRef<number>(-1)
   const {
@@ -227,6 +230,10 @@ const Banner = () => {
           .then((res) => {
             totalPageVar.current = res.data.totalPages
             setContent(res.data.content)
+            openToast({
+              message: '배너 글을 성공적으로 등록하였습니다.',
+              severity: 'success',
+            })
           })
       })
       .catch((err) => {
@@ -276,6 +283,10 @@ const Banner = () => {
           .then((res) => {
             totalPageVar.current = res.data.totalPages
             setContent(res.data.content)
+            openToast({
+              message: '배너 글을 성공적으로 수정하였습니다.',
+              severity: 'success',
+            })
           })
       })
       .catch((err) => {
@@ -336,6 +347,10 @@ const Banner = () => {
           })
           .then((res) => {
             setContent(res.data.content)
+            openToast({
+              message: `배너를 ${mode}처리 하였습니다.`,
+              severity: 'success',
+            })
           })
       })
       .catch(() => {
@@ -360,8 +375,13 @@ const Banner = () => {
           })
           .then((res) => {
             setContent(res.data.content)
+            openToast({
+              message: '배너 글을 성공적으로 삭제하였습니다.',
+              severity: 'success',
+            })
           })
-      }).catch((err) => {
+      })
+      .catch((err) => {
         alert('배너 삭제 실패 \n 사유: ' + err)
       })
   }

--- a/src/app/admin/banner/Banner.tsx
+++ b/src/app/admin/banner/Banner.tsx
@@ -669,7 +669,6 @@ const Banner = () => {
             {writeMode === 'view' ? (
               <Button
                 variant={'contained'}
-                // onClick={() => onHandleDelete(getValues('bannerId'))}
                 onClick={() => {
                   currentId.current = getValues('bannerId')
                   openRemoveModal()

--- a/src/app/admin/tag/Tag.tsx
+++ b/src/app/admin/tag/Tag.tsx
@@ -6,6 +6,8 @@ import { Button, Container, Stack, Typography } from '@mui/material'
 import axios from 'axios'
 import NewTag from './panel/NewTag'
 import { fetchTags } from '../panel/AdminAxios'
+import CuTextModal from '@/components/CuTextModal'
+import useModal from '@/hook/useModal'
 
 interface content {
   tagId: number
@@ -29,6 +31,14 @@ const Tag = () => {
   const [tagColor, setTagColor] = useState<string>('#000000')
   const [open, setOpen] = useState<boolean>(false)
   const writeMode = useRef<string>('')
+  const currentId = useRef<number>(-1)
+
+  const {
+    openModal: openRemoveModal,
+    closeModal: closeRemoveModal,
+    isOpen: isRemoveModalOpen,
+  } = useModal()
+
   useEffect(() => {
     fetchTags()
       .then((data) => setContent(data))
@@ -53,6 +63,7 @@ const Tag = () => {
         withCredentials: true,
       })
       .then(() => {
+        closeRemoveModal()
         alert(tagId + '번 태그가 삭제되었습니다.')
         fetchTags().then((data) => setContent(data))
       })
@@ -162,7 +173,12 @@ const Tag = () => {
                       수정
                     </Typography>
                   </Button>
-                  <Button onClick={() => onHandleRemove(item.tagId)}>
+                  <Button
+                    onClick={() => {
+                      currentId.current = item.tagId
+                      openRemoveModal()
+                    }}
+                  >
                     <Typography variant={'Body1'} sx={alignCenter}>
                       삭제
                     </Typography>
@@ -183,6 +199,20 @@ const Tag = () => {
             onHandleSubmit={onHandleSubmit}
           />
         </Stack>
+        <CuTextModal
+          title="태그 삭제하기"
+          open={isRemoveModalOpen}
+          onClose={closeRemoveModal}
+          content="정말 태그를 삭제하시겠습니까?"
+          textButton={{
+            text: '취소',
+            onClick: closeRemoveModal,
+          }}
+          containedButton={{
+            text: '삭제',
+            onClick: () => onHandleRemove(currentId.current),
+          }}
+        />
       </Container>
     </>
   )

--- a/src/app/admin/tag/Tag.tsx
+++ b/src/app/admin/tag/Tag.tsx
@@ -67,6 +67,9 @@ const Tag = () => {
         alert(tagId + '번 태그가 삭제되었습니다.')
         fetchTags().then((data) => setContent(data))
       })
+      .catch(() => {
+        alert('태그 삭제 실패 \n 사유: ' + err)
+      })
   }
 
   const onHandleSubmit = () => {

--- a/src/app/admin/tag/Tag.tsx
+++ b/src/app/admin/tag/Tag.tsx
@@ -67,7 +67,7 @@ const Tag = () => {
         alert(tagId + '번 태그가 삭제되었습니다.')
         fetchTags().then((data) => setContent(data))
       })
-      .catch(() => {
+      .catch((err) => {
         alert('태그 삭제 실패 \n 사유: ' + err)
       })
   }

--- a/src/app/admin/tag/Tag.tsx
+++ b/src/app/admin/tag/Tag.tsx
@@ -8,6 +8,7 @@ import NewTag from './panel/NewTag'
 import { fetchTags } from '../panel/AdminAxios'
 import CuTextModal from '@/components/CuTextModal'
 import useModal from '@/hook/useModal'
+import useToast from '@/states/useToast'
 
 interface content {
   tagId: number
@@ -32,6 +33,8 @@ const Tag = () => {
   const [open, setOpen] = useState<boolean>(false)
   const writeMode = useRef<string>('')
   const currentId = useRef<number>(-1)
+
+  const { openToast } = useToast()
 
   const {
     openModal: openRemoveModal,
@@ -64,7 +67,10 @@ const Tag = () => {
       })
       .then(() => {
         closeRemoveModal()
-        alert(tagId + '번 태그가 삭제되었습니다.')
+        openToast({
+          message: '태그가 성공적으로 삭제되었습니다.',
+          severity: 'success',
+        })
         fetchTags().then((data) => setContent(data))
       })
       .catch((err) => {
@@ -84,7 +90,10 @@ const Tag = () => {
           { withCredentials: true },
         )
         .then(() => {
-          alert('새로운 태그가 등록되었습니다.')
+          openToast({
+            message: '태그가 성공적으로 등록되었습니다.',
+            severity: 'success',
+          })
           fetchTags().then((data) => setContent(data))
         })
         .catch(() => {
@@ -102,7 +111,10 @@ const Tag = () => {
           { withCredentials: true },
         )
         .then(() => {
-          alert('태그가 수정되었습니다.')
+          openToast({
+            message: '태그가 성공적으로 수정되었습니다.',
+            severity: 'success',
+          })
           fetchTags().then((data) => setContent(data))
         })
         .catch(() => {

--- a/src/app/admin/tag/panel/NewTag.tsx
+++ b/src/app/admin/tag/panel/NewTag.tsx
@@ -32,6 +32,8 @@ const NewTag = ({
   setTagColor,
   onHandleSubmit,
 }: props) => {
+
+  // 태그 이름 유효성검사
   const [tagNameError, setTagNameError] = useState('')
 
   const validateTagName = (name: string) => {
@@ -40,6 +42,9 @@ const NewTag = ({
       return false
     } else if (name.length > 10) {
       setTagNameError('태그 이름은 10자를 초과할 수 없습니다.')
+      return false
+    } else if (/['"\\;% ]/.test(name)) {
+      setTagNameError('태그 이름에 유효하지 않은 문자가 포함되어 있습니다.')
       return false
     }
     setTagNameError('')
@@ -88,7 +93,6 @@ const NewTag = ({
           error={!!tagNameError}
           helperText={tagNameError}
           sx={{ display: 'flex', justifyContent: 'center' }}
-          // onChange={(e) => setTagName(e.target.value)}
           onChange={handleNameChange}
         />
         <Typography variant={'Body1'} align="center">


### PR DESCRIPTION
- 어드민 공지/배너/태그 관리에서 삭제시 더블체크 모달 추가
- alret 를 띄우는데 좀 번잡해보이는데...
- 공지글작성시 글제목 칸이 비어있으면 글쓴이 칸에도 에러메시지가 뜨는 현상 해결

<img width="713" alt="Screenshot 2024-02-07 at 1 15 16 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/87654307/66f41d27-42b0-45f1-9e59-fe0d8a7f7f9e">
<img width="1022" alt="Screenshot 2024-02-07 at 1 17 35 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/87654307/cd91ba15-7f55-49e0-b423-8312e5508729">
<img width="500" alt="Screenshot 2024-02-07 at 1 17 22 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/87654307/bc649e1e-cc24-413a-a4d0-ed2907abcbb7">

