### PR TITLE
[S-SC] 쇼케이스 아바타 및 폰트 컬러 수정

### DIFF
--- a/src/app/showcase/panel/common/TeamMembers.tsx
+++ b/src/app/showcase/panel/common/TeamMembers.tsx
@@ -5,6 +5,7 @@ import ListIcon from '@/icons/ListIcon'
 import * as Style from './SkillInput.style'
 import { IMember } from '@/types/IShowcaseEdit'
 import CuAvatar from '@/components/CuAvatar'
+import OthersProfile from '@/app/panel/OthersProfile'
 
 const MemberInformation = ({ member }: { member: IMember }) => {
   return (
@@ -15,12 +16,33 @@ const MemberInformation = ({ member }: { member: IMember }) => {
       width={'auto'}
       height={'auto'}
     >
-      <CuAvatar
-        src={member.image}
-        sx={{ width: '1.75rem', height: '1.75rem', border: '1px solid 2C2E35' }}
-      />
+      {member.nickname ? (
+        <OthersProfile userId={member.id} name={member.nickname}>
+          <CuAvatar
+            src={member.image ?? undefined}
+            alt="프로필 이미지"
+            sx={{
+              width: '1.75rem',
+              height: '1.75rem',
+              border: '1px solid 2C2E35',
+            }}
+          />
+        </OthersProfile>
+      ) : (
+        <CuAvatar
+          src={member.image ?? undefined}
+          alt="프로필 이미지"
+          sx={{
+            width: '1.75rem',
+            height: '1.75rem',
+            border: '1px solid 2C2E35',
+          }}
+        />
+      )}
+
       <Typography variant={'Body2'} sx={{ color: 'text.normal' }}>
-        {member.nickname}
+        {/* /탈퇴한 유저의 경우 image = null, nickname = 탈퇴한 유저, role = null */}
+        {member.nickname ?? '탈퇴한 유저'}
       </Typography>
       {member.isLeader && (
         <Typography variant={'Body2'} sx={{ color: 'purple.strong' }}>

--- a/src/components/ToastUIViewer.tsx
+++ b/src/components/ToastUIViewer.tsx
@@ -44,7 +44,7 @@ const ToastViewer = ({
           // 글자와 관련된 태그들을 최대한 다 넣어봤습니다.
           '& span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite,  del, dfn, em,  ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, section, summary, time, mark':
             {
-              color: 'text.alternative',
+              color: 'text.normal',
             },
         },
       }}

--- a/src/types/IShowcaseEdit.ts
+++ b/src/types/IShowcaseEdit.ts
@@ -7,10 +7,11 @@
 //   content: string
 // }
 export interface IMember {
-  nickname: string
+  id: string
+  nickname?: string
   isLeader?: boolean
-  role: string
-  image: string
+  role?: string
+  image?: string
 }
 
 export interface ILinkInformation {


### PR DESCRIPTION
### 수정사항 
1. 쇼케이스 내 아바타에 링크를 걸 수 있도록 OthersProfile 컴포넌트를 사용하였습니다.
2. 쇼케이스 디테일 페이지 내 시인성을 위하여 폰트 컬러를 수정하였습니다.

https://github.com/peer-42seoul/Peer-Frontend/issues/833
https://github.com/peer-42seoul/Peer-Frontend/issues/842