### PR TITLE
[S-SC] 쇼케이스 디자인 수정

### DIFF
--- a/src/app/showcase/panel/ShowcaseEditor.tsx
+++ b/src/app/showcase/panel/ShowcaseEditor.tsx
@@ -35,9 +35,7 @@ const ShowcaseEditor = ({
 }: IShowcaseEditorProps) => {
   const axiosWithAuth = useAxiosWithAuth()
   const [image, setImage] = useState<File[]>([])
-  const [previewImage, setPreviewImage] = useState<string>(
-    data.image ?? '/images/defaultImage.png',
-  )
+  const [previewImage, setPreviewImage] = useState<string>(data.image || '')
   const { openToast } = useToast()
   const { isOpen: alertOpen, closeModal, openModal } = useModal()
   const { links, addLink, deleteLink, changeLinkName, changeUrl } = useLinks(

--- a/src/app/showcase/panel/common/ImageInput.tsx
+++ b/src/app/showcase/panel/common/ImageInput.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Stack, Box, Typography } from '@mui/material'
+import { Stack, Box, Button } from '@mui/material'
 import React from 'react'
 import LabelWithIcon from '../../../../components/LabelWithIcon'
 import ImageIcon from '@/icons/ImageIcon'
@@ -23,41 +23,48 @@ const ImageInput = ({
         svgIcon={<ImageIcon sx={Style.IconStyle} />}
         message={'쇼케이스 대표 이미지'}
       />
-      <ImageUploadButton
-        setImage={(image: File[]) => {
-          setImage(image)
-        }}
-        setPreviewImage={setPreviewImage}
-        sx={Style.ShowcaseImageStyle}
-      >
-        {previewImage ? (
-          <Image src={previewImage} alt="쇼케이스 대표 이미지" fill={true} />
-        ) : (
+      <Stack sx={{ display: 'flex', alignItems: 'center' }}>
+        {previewImage && (
           <Box
-            sx={{
-              ...Style.ShowcaseImageStyle,
+            style={{
               position: 'relative',
-              backgroundColor: 'background.tertiary',
+              maxWidth: '26rem',
+              width: '100%',
+              height: 300,
+              margin: 0,
             }}
           >
-            <Typography
-              variant={'Body1'}
-              sx={{
-                color: 'text.normal',
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                width: 'auto',
-              }}
-            >
-              클릭해서 이미지를
-              <br />
-              업로드하세요
-            </Typography>
+            <Image
+              src={previewImage}
+              alt="쇼케이스 대표 이미지"
+              layout="fill"
+            />
           </Box>
         )}
-      </ImageUploadButton>
+        <ImageUploadButton
+          setImage={(image: File[]) => {
+            setImage(image)
+          }}
+          setPreviewImage={setPreviewImage}
+          sx={{ color: 'primary' }}
+        >
+          <Stack
+            direction={'column'}
+            spacing={'0.5rem'}
+            sx={{ width: ['100%', '26rem'] }}
+          >
+            <Button
+              component="div"
+              variant="outlined"
+              // startIcon={<Icon.PlusIcon color={'primary'} />}
+              sx={{ width: ['100%', '26rem'] }}
+              color={'primary'}
+            >
+              대표이미지 등록
+            </Button>
+          </Stack>
+        </ImageUploadButton>
+      </Stack>
     </Stack>
   )
 }

--- a/src/app/showcase/write/page.tsx
+++ b/src/app/showcase/write/page.tsx
@@ -8,6 +8,8 @@ import useAxiosWithAuth from '@/api/config'
 import useSWR from 'swr'
 import CuCircularProgress from '@/components/CuCircularProgress'
 import { useRouter, useSearchParams } from 'next/navigation'
+import NoDataDolphin from '@/components/NoDataDolphin'
+import Link from 'next/link'
 
 const ShowCaseWritePage = () => {
   const router = useRouter()
@@ -25,7 +27,17 @@ const ShowCaseWritePage = () => {
   if (error) {
     if (error.response && error.response.status === 409) {
       return (
-        <Typography color={'error'}>{error.response.data.message}</Typography>
+        <Stack
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-around',
+            alignItems: 'center',
+            height: '90vh',
+          }}
+        >
+          <NoDataDolphin message={error.response.data.message} />
+          <Link href={`../teams/${teamId}/setting`}>팀설정으로 돌아가기</Link>
+        </Stack>
       )
     }
     return <Typography color={'error'}>에러가 발생했습니다.</Typography>


### PR DESCRIPTION
### 수정사항

<img width="150" alt="Screenshot 2024-02-07 at 6 29 48 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/62472550/cec3e215-d6f9-4c4d-9057-2d0dd0e15a04">

- 이미지 삽입 버튼의 디자인 통일성을 위하여 수정하였습니다.

<img width="150" alt="Screenshot 2024-02-07 at 6 29 14 PM" src="https://github.com/peer-42seoul/Peer-Frontend/assets/62472550/eec9a676-b5be-4cf4-959c-49a027cc3888">

- 팀설정이 완료되지 않은 유저가 쇼케이스를 작성할 시 응답하는 에러 페이지의 스타일을 추가하였습니다.
- 
https://github.com/peer-42seoul/Peer-Frontend/issues/860