### PR TITLE
[PUBLIC] SkillAutocomplete 컴포넌트에서 간헐적으로 선택한 태그가 사라지는 현상 수정

### DIFF
--- a/src/components/SkillAutocomplete.tsx
+++ b/src/components/SkillAutocomplete.tsx
@@ -79,23 +79,6 @@ const SkillAutocomplete = ({
     }
   }, [timeOut])
 
-  // const handleTextFieldChange = (
-  //   event: React.SyntheticEvent,
-  //   value: string,
-  //   reason: string,
-  // ) => {
-  //   if (reason === 'input') {
-  //     setText(value)
-  //     if (value) {
-  //       setIsLoading(false)
-  //       return
-  //     } else if (isLoading === false) {
-  //       setIsLoading(true)
-  //     }
-  //     setTimeOut(TIMEOUT)
-  //   }
-  // }
-
   const handleTextFieldChange = (e: any) => {
     setText(e.target.value)
     if (e.target.value === '') {
@@ -108,6 +91,9 @@ const SkillAutocomplete = ({
   }
 
   const handleInput = (_: any, value: string[]) => {
+    if (value.length < skillList.length) {
+      return
+    }
     const newSkillList: ISkill[] = []
     value.map((newValue) => {
       newSkillList.push(


### PR DESCRIPTION
### 수정 사항
1. 입력한 텍스트가 없는 상태에서 백스페이스를 누르면 선택한 태그가 예기치 않게 사라지던 버그가 수정되었습니다. 