### PR TITLE
[H-HITCH] 히치하이킹 카드 뒷면 밀림 현상 수정 

### DIFF
--- a/src/app/hitchhiking/panel/HitchhikingCard.tsx
+++ b/src/app/hitchhiking/panel/HitchhikingCard.tsx
@@ -179,10 +179,23 @@ const HitchhikingCardBack = ({
                   fontSize: '0.75rem',
                   color: 'text.alternative',
                   margin: 0,
+                  lineHeight: '1.125rem',
+                  marginBlockStart: '0',
+                  marginBlockEnd: '0',
+                  marginTop: 0,
                 }}
                 sx={{
                   ...style.cardContentStyleBase,
                   WebkitLineClamp: getLineCount(46, 18, 10) /* 라인수 */,
+                  '& .toastui-editor-contents > h1:first-of-type': {
+                    marginTop: 0,
+                  },
+                  '.toastui-editor-contents h1': {
+                    paddingBottom: 0,
+                  },
+                  '.toastui-editor-contents h2': {
+                    paddingBottom: 0,
+                  },
                 }}
               />
             </Box>


### PR DESCRIPTION
### 변경 사항
1. 히치하이킹 카드 뒷면에서 h1, h2태그에 margin, padding이 적용되어있는 문제를 해결하였습니다.

#### 수정 전
<img width="270" alt="스크린샷 2024-02-07 오후 7 42 18" src="https://github.com/peer-42seoul/Peer-Frontend/assets/91731260/a425ab0a-60ae-498d-b051-3986698cadc7">

#### 수정 후 
<img width="278" alt="스크린샷 2024-02-07 오후 7 40 19" src="https://github.com/peer-42seoul/Peer-Frontend/assets/91731260/0e43f16b-660d-41a6-8e36-da7c638cc825">
