### PR TITLE
[1.0.3 / J-TB] 모집글 삭제 기능 추가

### DIFF
--- a/src/app/recruit/[id]/panel/RecruitQuickMenu.tsx
+++ b/src/app/recruit/[id]/panel/RecruitQuickMenu.tsx
@@ -1,12 +1,18 @@
 import { Stack } from '@mui/material'
+import useAxiosWithAuth from '@/api/config'
 import FavoriteButton from '@/components/FavoriteButton'
 import React, { useEffect, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import ShareMenuItem from '@/components/dropdownMenu/ShareMenuItem'
 import DropdownMenu from '@/components/DropdownMenu'
-import * as style from '@/components/dropdownMenu/dropdownMenu.styles'
 import IconMenuItem from '@/components/dropdownMenu/IconMenuItem'
+import useToast from '@/states/useToast'
+import useModal from '@/hook/useModal'
 import WriteIcon from '@/icons/Nav/WriteIcon'
+import { TrashLineIcon } from '@/icons'
+import * as style from '@/components/dropdownMenu/dropdownMenu.styles'
+import { isAxiosError } from 'axios'
+import CuTextModal from '@/components/CuTextModal'
 
 const RecruitQuickMenu = ({
   favorite,
@@ -25,43 +31,94 @@ const RecruitQuickMenu = ({
   const type = useSearchParams().get('type')
   const router = useRouter()
   const [currentPageUrl, setCurrentPageUrl] = useState('')
+  const axiosWithAuth = useAxiosWithAuth()
+  const [isDeleting, setIsDeleting] = useState(false)
+  const { openToast } = useToast()
+  const { isOpen, openModal: openConfirmModal, closeModal } = useModal()
 
   //window is not defined 에러 방지
   useEffect(() => {
     setCurrentPageUrl(window.location.href)
   }, [])
 
+  const handleDelete = () => {
+    setIsDeleting(true)
+    axiosWithAuth
+      .delete(`/api/v1/recruit/${recruit_id}`)
+      .then(() => {
+        alert('모집글을 삭제했습니다.')
+        router.push('/') // 모집글을 삭제한 뒤 메인으로 이동.
+      })
+      .catch((error: unknown) => {
+        if (
+          isAxiosError(error) &&
+          error.response?.status === 400 &&
+          error.response.data.message
+        ) {
+          openToast({
+            severity: 'error',
+            message: error.response.data.message,
+          })
+        } else {
+          openToast({
+            severity: 'error',
+            message: '모집글 삭제에 실패했습니다.',
+          })
+        }
+      })
+      .finally(() => {
+        setIsDeleting(false)
+        closeModal()
+      })
+  }
+
   return (
-    <Stack flexDirection={'row'} justifyContent={'flex-end'}>
-      <FavoriteButton
-        favorite={favorite}
-        recruit_id={recruit_id}
-        redirect_url={`${path}?type=${type}`}
-      />
-      <DropdownMenu>
-        <ShareMenuItem
-          title={title}
-          url={currentPageUrl}
-          content={content}
-          message={currentPageUrl}
+    <>
+      <Stack flexDirection={'row'} justifyContent={'flex-end'}>
+        <FavoriteButton
+          favorite={favorite}
+          recruit_id={recruit_id}
+          redirect_url={`${path}?type=${type}`}
         />
-        {me && (
-          <IconMenuItem
-            action={() => router.push(`/recruit/${recruit_id}/edit`)}
-            icon={
-              <WriteIcon
-                sx={{
-                  ...style.menuItemIconStyleBase,
-                  padding: '0.125rem',
-                  color: 'text.alternative',
-                }}
-              />
-            }
-            text={'수정'}
+        <DropdownMenu>
+          <ShareMenuItem
+            title={title}
+            url={currentPageUrl}
+            content={content}
+            message={currentPageUrl}
           />
-        )}
-      </DropdownMenu>
-    </Stack>
+          {me && (
+            <IconMenuItem
+              action={() => router.push(`/recruit/${recruit_id}/edit`)}
+              icon={<WriteIcon sx={style.recruitMenuIcon} />}
+              text={'수정'}
+            />
+          )}
+          {me && (
+            <IconMenuItem
+              action={openConfirmModal}
+              icon={<TrashLineIcon sx={style.recruitMenuIcon} />}
+              text={'삭제'}
+            />
+          )}
+        </DropdownMenu>
+      </Stack>
+      <CuTextModal
+        open={isOpen}
+        onClose={closeModal}
+        title={'모집글을 삭제할까요?'}
+        content={'승인된 팀원이 있거나 모집이 완료된 경우 삭제할 수 없어요.'}
+        textButton={{
+          text: '취소',
+          onClick: closeModal,
+        }}
+        containedButton={{
+          text: '삭제',
+          onClick: handleDelete,
+          isLoading: isDeleting,
+        }}
+      />
+    </>
   )
 }
 

--- a/src/components/dropdownMenu/dropdownMenu.styles.ts
+++ b/src/components/dropdownMenu/dropdownMenu.styles.ts
@@ -12,3 +12,9 @@ export const menuItemIconStyleBase: SxProps = {
   height: '1.5rem',
   boxSizing: 'border-box',
 }
+
+export const recruitMenuIcon: SxProps = {
+  ...menuItemIconStyleBase,
+  padding: '0.125rem',
+  color: 'text.alternative',
+}


### PR DESCRIPTION
### 관련 이슈

- close #925

### 작업 내용

본인이 작성한 모집글인 경우에 드롭다운에 삭제 버튼을 띄우고 삭제 요청을 할 수 있게 했습니다. => 삭제 성공시 메인화면으로 이동

삭제가 실패하는 경우
- 승인된 팀원이 있는 경우
- 모집이 완료된 경우

 
<img width="763" alt="Screen_Shot 2024-02-12 19 43 17" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/b42191b6-f6ee-4c79-a0ca-560119d48465">
<img width="763" alt="Screen_Shot 2024-02-12 19 43 34" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/e6265be3-2734-452c-8f3a-2c8e64d4b96a">
