### PR TITLE
[1.0.3 / C-SIGN] accessToken cookie 처리 부분 삭제, logout 함수 수정

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -34,7 +34,7 @@ const useAxiosWithAuth = () => {
       if (error.response?.status === 401) {
         if (!accessToken || isRefreshing) {
           // 로그아웃 후 리디렉션
-          useAuthStore.getState().logout()
+          useAuthStore.getState().logout(isRefreshing)
           router.push('/login?redirect=' + currentPageUrl)
         } else {
           isRefreshing = true
@@ -51,7 +51,7 @@ const useAxiosWithAuth = () => {
           } catch (refreshError) {
             // 로그아웃 후 리디렉션
             isRefreshing = true
-            useAuthStore.getState().logout()
+            useAuthStore.getState().logout(isRefreshing)
             router.push('/login?redirect=' + currentPageUrl)
           }
         }

--- a/src/app/login/oauth/page.tsx
+++ b/src/app/login/oauth/page.tsx
@@ -4,7 +4,6 @@ import { Typography, Stack, CircularProgress } from '@mui/material'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import useAuthStore from '@/states/useAuthStore'
-import { setCookie } from 'cookies-next'
 
 const OauthLogin = () => {
   const router = useRouter()
@@ -14,7 +13,6 @@ const OauthLogin = () => {
     const accessToken = searchParams.get('accessToken')
     if (accessToken) {
       login(accessToken)
-      setCookie('accessToken', accessToken)
       router.push('/')
     } else {
       window.alert('로그인에 실패했습니다')

--- a/src/states/useAuthStore.tsx
+++ b/src/states/useAuthStore.tsx
@@ -1,14 +1,13 @@
 import { create } from 'zustand'
 import LocalStorage from './localStorage'
 import axios from 'axios'
-import { setCookie } from 'cookies-next'
 import useNicknameStore from './useNicknameStore'
 
 interface IAuthStore {
   isLogin: boolean
   accessToken: string | null
   login: (accessToken: string) => void
-  logout: () => void
+  logout: (isRefreshing?: boolean) => void
 }
 
 const useAuthStore = create<IAuthStore>((set) => {
@@ -25,7 +24,6 @@ const useAuthStore = create<IAuthStore>((set) => {
     login: (accessToken) => {
       const authDataToSave = { accessToken }
       LocalStorage.setItem('authData', JSON.stringify(authDataToSave))
-      setCookie('accessToken', accessToken)
       axios
         .get(`${API_URL}/api/v1/profile`, {
           headers: {
@@ -42,13 +40,14 @@ const useAuthStore = create<IAuthStore>((set) => {
         accessToken,
       }))
     },
-    logout: () => {
-      if (authData.accessToken) {
-        axios.get(`${API_URL}/api/v1/logout`, {
-          headers: {
-            Authorization: `Bearer ${authData.accessToken}`,
-          },
-        })
+    logout: (isRefreshing) => {
+      if (authData.accessToken && !isRefreshing) {
+        axios
+          .get(`${API_URL}/api/v1/logout`, {
+            headers: {
+              Authorization: `Bearer ${authData.accessToken}`,
+            },
+          })
       }
       LocalStorage.removeItem('authData')
       set(() => ({


### PR DESCRIPTION
- accessToken이 만료된 이후 reissue를 시도하고 logout을 처리하는 과정에서 401에러가 발생하는 경우가 있어 logout 함수를 수정했습니다.
- 이전에 accessToken을 쿠키에 담으려했던 코드 일부가 남아있어 삭제했습니다.

resolves: #914 