### PR TITLE
[1.0.3 / C-MYPAGE] 모바일 쪽지 삭제 버그 수정

### DIFF
--- a/src/app/my-page/message/@list/panel/MobileMessageItem.style.ts
+++ b/src/app/my-page/message/@list/panel/MobileMessageItem.style.ts
@@ -16,7 +16,9 @@ export const swappableWrapper = {
 
 export const removeButton = {
   boxSizing: 'border-box',
-  width: '2.5rem',
+  // width: '2.5rem',
+  minWidth: '2.5rem',
+  maxWidth: '2.5rem',
   height: '4.5rem',
   display: 'flex',
   flexDirection: 'column',

--- a/src/app/my-page/message/@list/panel/MobileMessageItem.tsx
+++ b/src/app/my-page/message/@list/panel/MobileMessageItem.tsx
@@ -1,4 +1,5 @@
 import { TouchEvent, useState, ReactNode, useRef } from 'react'
+import { useSWRConfig } from 'swr'
 import { Box, ListItem, ListItemButton, Stack } from '@mui/material'
 import useAxiosWithAuth from '@/api/config'
 import CuButton from '@/components/CuButton'
@@ -112,11 +113,15 @@ const MobileMessageListItem = ({ message }: IMobileMessageListItemProps) => {
   const { targetId, conversationId } = message
   const listItemRef = useRef(null)
   const { openToast } = useToast()
+  const { mutate } = useSWRConfig()
 
   const deleteOneMessage = () => {
     axiosWithAuth
       .delete('/api/v1/message/delete-message', {
-        data: { target: [{ targetId }] },
+        data: { target: [{ conversationId }] },
+      })
+      .then(() => {
+        mutate('/api/v1/message/list')
       })
       .catch(() => {
         openToast({


### PR DESCRIPTION
### 관련 이슈

- close #946

### 작업 내용

<img width="30%" alt="Screen_Shot 2024-02-13 22 22 25" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/6c7e48a7-be81-41cb-84bd-3a6293442644">

1. 모바일에서 쪽지 삭제 안됨
=> 좋은 구조는 아니지만;; 모바일에서 삭제 api를 호출하는 부분이 pc와 다른데 이 부분에서는 api request body의 수정사항이 반영되지 않았던 것이 문제였습니다. body 수정해서 삭제 되는 것까지 확인했습니다.
2. 삭제 버튼 너비 줄어듦
=> 원인은 모르겠는데 width 설정이 반영되지 않는 상황입니다. (테마에 min-width가 적용되어 있긴 한데 20px로 설정하려는 width 보다는 작은값입니다.) 일단은 삭제 버튼의 min-width, max-width를 모두 2.5rem으로 지정해서 문제를 해결해두었습니다 🥲
