### PR TITLE
[1.0.3 / D-TP] 팀 페이지 사이드바 디자인 보완

### DIFF
--- a/src/app/teams/[id]/panel/NavBar.tsx
+++ b/src/app/teams/[id]/panel/NavBar.tsx
@@ -10,7 +10,7 @@ import {
   SettingIcon,
   ShowcaseIcon,
 } from '@/icons/TeamPage'
-import { Box, useMediaQuery } from '@mui/material'
+import { Box } from '@mui/material'
 import useMedia from '@/hook/useMedia'
 import * as style from './NavBar.style'
 import * as navStyle from '@/components/NavBarBox.style'
@@ -26,11 +26,10 @@ const getTabValue = (path: string) => {
 
 const TeamSidebar = ({ id }: { id: string }) => {
   const router = useRouter()
-  const isTablet = useMediaQuery('(min-width:480px) and (max-width:997px)') // TODO : useMedia에 추가하는 방안 고려해보기
-  const { isPc } = useMedia()
+  const { isPc, isLargeTablet } = useMedia()
 
   return (
-    <Box sx={getNavStyle(isTablet, isPc)}>
+    <Box sx={getNavStyle(isLargeTablet, isPc)}>
       <CuNavBar
         getTabValue={getTabValue}
         title={'나의 팀들'}

--- a/src/app/teams/[id]/panel/NavBar.tsx
+++ b/src/app/teams/[id]/panel/NavBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import CuNavBar from '@/components/CuNavBar'
 import {
   BoardIcon,
@@ -10,20 +10,10 @@ import {
   SettingIcon,
   ShowcaseIcon,
 } from '@/icons/TeamPage'
-import {
-  Badge,
-  Box,
-  Stack,
-  ToggleButton,
-  Typography,
-  useMediaQuery,
-} from '@mui/material'
-import { ReactElement, useCallback, useEffect, useState } from 'react'
-import { ToggleButtonGroup } from '@mui/material'
+import { Box, useMediaQuery } from '@mui/material'
 import useMedia from '@/hook/useMedia'
 import * as style from './NavBar.style'
 import * as navStyle from '@/components/NavBarBox.style'
-import * as CuStyle from '@/components/CuNavBar.style'
 
 const getTabValue = (path: string) => {
   if (path.includes('/notice')) return 'notice'
@@ -34,160 +24,17 @@ const getTabValue = (path: string) => {
   else return 'main'
 }
 
-interface ITabInfo {
-  label: string
-  mobileLabel?: string
-  onClick: () => void
-  value: string
-  icon: ReactElement
-  disabled?: boolean
-  new?: boolean
-  isBeta?: boolean
-}
-
-interface ICuNavBarProps {
-  getTabValue: (path: string) => string
-  tabData: ITabInfo[]
-}
-
-const MobileSidebar = ({ getTabValue, tabData }: ICuNavBarProps) => {
-  const pathName = usePathname()
-  const [value, setValue] = useState<string | undefined>(undefined)
-
-  const setTabValue = useCallback(() => {
-    setValue(getTabValue(pathName))
-  }, [pathName, getTabValue])
-
-  useEffect(() => {
-    setTabValue()
-  }, [setTabValue])
-
-  return (
-    <Box sx={{ marginBottom: '2rem', width: '70%' }}>
-      <ToggleButtonGroup
-        orientation={'horizontal'}
-        fullWidth={false}
-        value={value}
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          width: '100%',
-          padding: 0,
-          '& .MuiToggleButtonGroup-grouped': {
-            borderRadius: '0.5rem',
-          },
-        }}
-        exclusive
-        onChange={(_event, newValue) => {
-          if (newValue) setValue(newValue)
-        }}
-      >
-        {[
-          tabData.map((tab) => (
-            <MobileToggleButton
-              key={crypto.randomUUID()}
-              tab={tab}
-              selected={value === tab.value}
-              width={180 / tabData.length}
-            />
-          )),
-        ]}
-      </ToggleButtonGroup>
-    </Box>
-  )
-}
-
-const MobileToggleButton = ({
-  tab,
-  selected,
-  width,
-}: {
-  tab: ITabInfo
-  selected: boolean
-  width: number
-}) => {
-  const isNewTab = tab.new && !tab.disabled
-  return (
-    <ToggleButton
-      value={tab.value}
-      onClick={tab.onClick}
-      sx={{ ...CuStyle.mobileTab, width: `${width}%` }}
-      disabled={tab.disabled}
-      selected={selected}
-    >
-      <Stack direction={'column'} spacing={'0.12rem'} alignItems={'center'}>
-        <Badge
-          sx={isNewTab ? CuStyle.newBadge : CuStyle.betaBadge}
-          variant={'dot'}
-          invisible={!isNewTab && !tab.isBeta}
-        >
-          <Box sx={CuStyle.iconBoxBase}>{tab.icon}</Box>
-        </Badge>
-        <Typography variant={'Tag'}>{tab.mobileLabel ?? tab.label}</Typography>
-      </Stack>
-    </ToggleButton>
-  )
-}
-
 const TeamSidebar = ({ id }: { id: string }) => {
   const router = useRouter()
-  const isTablet = useMediaQuery('(min-width: 997px)')
+  const isTablet = useMediaQuery('(min-width:480px) and (max-width:997px)') // TODO : useMedia에 추가하는 방안 고려해보기
   const { isPc } = useMedia()
 
-  if (!isTablet && isPc) {
-    return (
-      <MobileSidebar
-        getTabValue={getTabValue}
-        tabData={[
-          {
-            label: '메인',
-            onClick: () => router.push(`/teams/${id}`),
-            value: 'main',
-            icon: <MainIcon sx={style.main} />,
-          },
-          {
-            label: '공지사항',
-            onClick: () => router.push(`/teams/${id}/notice`),
-            value: 'notice',
-            icon: <NoticeIcon sx={style.notice} />,
-          },
-          {
-            label: '게시판',
-            onClick: () => router.push(`/teams/${id}/board`),
-            value: 'board',
-            icon: <BoardIcon sx={style.board} />,
-          },
-          {
-            label: '팀설정',
-            onClick: () => router.push(`/teams/${id}/setting`),
-            value: 'setting',
-            icon: <SettingIcon sx={style.setting} />,
-          },
-          {
-            label: '피어로그',
-            onClick: () => router.push(`/teams/${id}/peerlog`),
-            value: 'peerlog',
-            icon: <PeerlogIcon sx={style.peerlog} />,
-            isBeta: true,
-            disabled: true,
-          },
-          {
-            label: '쇼케이스',
-            onClick: () => router.push(`/teams/${id}/showcase`),
-            value: 'showcase',
-            icon: <ShowcaseIcon sx={style.showcase} />,
-            new: true,
-          },
-        ]}
-      />
-    )
-  }
-
   return (
-    <Box sx={isPc ? navStyle.pcNavBar : navStyle.mobileNavBar}>
+    <Box sx={getNavStyle(isTablet, isPc)}>
       <CuNavBar
         getTabValue={getTabValue}
         title={'나의 팀들'}
+        tabletMode
         tabData={[
           {
             label: '메인',
@@ -218,7 +65,7 @@ const TeamSidebar = ({ id }: { id: string }) => {
             onClick: () => router.push(`/teams/${id}/peerlog`),
             value: 'peerlog',
             icon: <PeerlogIcon sx={style.peerlog} />,
-            isBeta: true,
+            isSoon: true,
             disabled: true,
           },
           {
@@ -226,12 +73,18 @@ const TeamSidebar = ({ id }: { id: string }) => {
             onClick: () => router.push(`/teams/${id}/showcase`),
             value: 'showcase',
             icon: <ShowcaseIcon sx={style.showcase} />,
-            new: true,
+            isNew: true,
           },
         ]}
       />
     </Box>
   )
+}
+
+const getNavStyle = (isTablet: boolean, isPc: boolean) => {
+  if (isTablet) return navStyle.tabletNavBar
+  if (isPc) return navStyle.pcNavBar
+  return navStyle.mobileNavBar
 }
 
 export default TeamSidebar

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -1,4 +1,4 @@
-import { SxProps, Theme } from '@mui/material'
+import { SxProps } from '@mui/material'
 
 export const pcNavBar = {
   boxSizing: 'border-box',
@@ -24,7 +24,7 @@ export const tabs = {
 const tabBase = {
   border: 'none',
   svg: {
-    fill: (theme: Theme) => theme.palette.text.assistive,
+    fill: 'text.assistive',
   },
 }
 
@@ -35,7 +35,7 @@ const selectedTab = {
       color: 'purple.normal',
     },
     '& svg': {
-      fill: (theme: Theme) => theme.palette.purple.normal,
+      fill: 'purple.normal',
     },
   },
 }
@@ -48,7 +48,7 @@ const disabledTab = {
       color: 'text.disable',
     },
     '& svg': {
-      fill: (theme: Theme) => theme.palette.text.disable,
+      fill: 'text.disable',
     },
   },
 }
@@ -102,17 +102,17 @@ const textBadge = {
 
 export const disabledTextBadge = {
   ...textBadge,
-  color: (theme: Theme) => theme.palette.text.disable + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+  color: 'text.disable' + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 export const newTextBadge = {
   ...textBadge,
-  color: (theme: Theme) => theme.palette.yellow.strong + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+  color: 'yellow.strong' + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 export const soonTextBadge = {
   ...textBadge,
-  color: (theme: Theme) => theme.palette.text.disable + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+  color: 'text.disable' + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 const BADGE_TRANSLATE = 'translate(130%, -50%)'
@@ -138,24 +138,24 @@ export const badgeBase = {
 
 export const newBadge = {
   '& .MuiBadge-badge': {
-    backgroundColor: (theme: Theme) => theme.palette.yellow.strong,
+    backgroundColor: 'yellow.strong',
   },
 }
 
 export const betaBadge = {
   '& .MuiBadge-badge': {
-    backgroundColor: (theme: Theme) => theme.palette.red.strong,
+    backgroundColor: 'red.strong',
   },
 }
 
 export const soonBadge = {
   '& .MuiBadge-badge': {
-    backgroundColor: (theme: Theme) => theme.palette.text.disable,
+    backgroundColor: 'text.disable',
   },
 }
 
 export const disabledBadge = {
   '& .MuiBadge-badge': {
-    backgroundColor: (theme: Theme) => theme.palette.text.disable,
+    backgroundColor: 'text.disable',
   },
 }

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -30,12 +30,12 @@ const tabBase = {
 
 const selectedTab = {
   '&.Mui-selected': {
-    backgroundColor: ['purple.tinted', 'background.tertiary'],
+    backgroundColor: 'purple.tinted',
     '& span': {
-      color: ['purple.strong', 'text.normal'],
+      color: 'purple.normal',
     },
     '& svg': {
-      fill: (theme: Theme) => theme.palette.purple.strong,
+      fill: (theme: Theme) => theme.palette.purple.normal,
     },
   },
 }
@@ -120,7 +120,6 @@ export const badgeBase = {
     width: '3px',
     minWidth: '3px', // mui 기본 설정 디자인 오버라이딩
     height: '3px',
-    backgroundColor: (theme: Theme) => theme.palette.yellow.strong,
     // mui 기본 설정 디자인 오버라이딩
     transform: `scale(1) ${BADGE_TRANSLATE}`,
     WebkitTransform: `scale(1) ${BADGE_TRANSLATE}`,

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -42,9 +42,11 @@ const selectedTab = {
 
 const disabledTab = {
   '&.Mui-disabled': {
-    color: 'text.disable',
     backgroundColor: 'transparent',
     border: 'none',
+    '& span': {
+      color: 'text.disable',
+    },
     '& svg': {
       fill: (theme: Theme) => theme.palette.text.disable,
     },

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -1,4 +1,4 @@
-import { SxProps } from '@mui/material'
+import { SxProps, Theme } from '@mui/material'
 
 export const pcNavBar = {
   boxSizing: 'border-box',
@@ -24,7 +24,7 @@ export const tabs = {
 const tabBase = {
   border: 'none',
   svg: {
-    fill: 'text.assistive',
+    fill: (theme: Theme) => theme.palette.text.assistive,
   },
 }
 
@@ -35,7 +35,7 @@ const selectedTab = {
       color: 'purple.normal',
     },
     '& svg': {
-      fill: 'purple.normal',
+      fill: (theme: Theme) => theme.palette.purple.normal,
     },
   },
 }
@@ -48,7 +48,7 @@ const disabledTab = {
       color: 'text.disable',
     },
     '& svg': {
-      fill: 'text.disable',
+      fill: (theme: Theme) => theme.palette.text.disable,
     },
   },
 }
@@ -60,12 +60,12 @@ export const pcTab: SxProps = {
   width: '100%',
   padding: '0 1.5rem',
   margin: '0.25rem 0',
-  '& span': {
-    color: 'text.assistive',
-  },
   ...tabBase,
   ...selectedTab,
   ...disabledTab,
+  '& span': {
+    color: 'text.assistive',
+  },
 }
 
 export const tabWithBadge = {
@@ -102,17 +102,17 @@ const textBadge = {
 
 export const disabledTextBadge = {
   ...textBadge,
-  color: 'text.disable' + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+  color: (theme: Theme) => theme.palette.text.disable + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 export const newTextBadge = {
   ...textBadge,
-  color: 'yellow.strong' + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+  color: (theme: Theme) => theme.palette.yellow.strong + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 export const soonTextBadge = {
   ...textBadge,
-  color: 'text.disable' + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+  color: (theme: Theme) => theme.palette.text.disable + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 const BADGE_TRANSLATE = 'translate(130%, -50%)'

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -66,7 +66,7 @@ export const pcTab: SxProps = {
   ...disabledTab,
 }
 
-export const newTab = {
+export const tabWithBadge = {
   padding: '0 1.5rem 0 4.06rem',
 }
 
@@ -93,10 +93,9 @@ export const iconBoxBase = {
   },
 }
 
-export const newTextBadge = {
+export const textBadge = {
   display: 'float',
   marginLeft: '1rem !important', // stack의 spacing을 덮어씌우기 위해 !important 사용
-  color: 'yellow.strong',
 }
 
 const BADGE_TRANSLATE = 'translate(130%, -50%)'
@@ -130,5 +129,17 @@ export const newBadge = {
 export const betaBadge = {
   '& .MuiBadge-badge': {
     backgroundColor: (theme: Theme) => theme.palette.red.strong,
+  },
+}
+
+export const soonBadge = {
+  '& .MuiBadge-badge': {
+    backgroundColor: (theme: Theme) => theme.palette.text.disable,
+  },
+}
+
+export const disabledBadge = {
+  '& .MuiBadge-badge': {
+    backgroundColor: (theme: Theme) => theme.palette.text.disable,
   },
 }

--- a/src/components/CuNavBar.style.ts
+++ b/src/components/CuNavBar.style.ts
@@ -93,9 +93,24 @@ export const iconBoxBase = {
   },
 }
 
-export const textBadge = {
+const textBadge = {
   display: 'float',
   marginLeft: '1rem !important', // stack의 spacing을 덮어씌우기 위해 !important 사용
+}
+
+export const disabledTextBadge = {
+  ...textBadge,
+  color: (theme: Theme) => theme.palette.text.disable + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+}
+
+export const newTextBadge = {
+  ...textBadge,
+  color: (theme: Theme) => theme.palette.yellow.strong + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
+}
+
+export const soonTextBadge = {
+  ...textBadge,
+  color: (theme: Theme) => theme.palette.text.disable + ' !important', // 버튼 테마 설정을 덮어씌우기 위해 !important 사용
 }
 
 const BADGE_TRANSLATE = 'translate(130%, -50%)'

--- a/src/components/CuNavBar.tsx
+++ b/src/components/CuNavBar.tsx
@@ -148,6 +148,7 @@ const PcToggleButton = ({
         alignItems={'center'}
         justifyContent={'center'}
       >
+        <Box sx={style.iconBoxBase}>{tab.icon}</Box>
         <Typography variant={'Caption'}>{tab.label}</Typography>
         <PcButtonBadge
           isNew={tab.isNew}

--- a/src/components/CuNavBar.tsx
+++ b/src/components/CuNavBar.tsx
@@ -8,27 +8,37 @@ import {
   ToggleButtonGroup,
   ToggleButton,
   Badge,
+  useMediaQuery,
 } from '@mui/material'
 import useMedia from '@/hook/useMedia'
 import { ChevronLeft } from '@/icons'
 import { BetaIcon } from '@/components/BetaBadge'
 import * as style from './CuNavBar.style'
 
-interface ITabInfo {
+interface IBadgeInfo {
+  isNew?: boolean
+  isBeta?: boolean
+  isSoon?: boolean
+}
+
+interface IButtonBadgeProps extends IBadgeInfo {
+  disabled?: boolean
+}
+
+interface ITabInfo extends IBadgeInfo {
   label: string
   mobileLabel?: string
   onClick: () => void
   value: string
   icon: ReactElement
   disabled?: boolean
-  new?: boolean
-  isBeta?: boolean
 }
 
 interface ICuNavBarProps {
   getTabValue: (path: string) => string
   title: string
   prevButtonAction?: () => void
+  tabletMode?: boolean // 팀 페이지 navBar와 같이 태블릿 사이즈에서도 모바일 sidebar 형태로 보여줄 때 사용
   tabData: ITabInfo[]
 }
 
@@ -37,10 +47,13 @@ const CuNavBar = ({
   title,
   prevButtonAction,
   tabData,
+  tabletMode,
 }: ICuNavBarProps) => {
   const pathName = usePathname()
   const [value, setValue] = useState<string | undefined>(undefined)
   const { isPc } = useMedia()
+  const isTablet = useMediaQuery('(min-width:480px) and (max-width:997px)') // TODO : useMedia에 추가하는 방안 고려해보기
+  const [isPcSidebar, setIsPcSidebar] = useState<boolean>(false)
 
   const setTabValue = useCallback(() => {
     setValue(getTabValue(pathName))
@@ -50,9 +63,17 @@ const CuNavBar = ({
     setTabValue()
   }, [setTabValue])
 
+  useEffect(() => {
+    if (tabletMode) {
+      setIsPcSidebar(!isTablet && isPc)
+    } else {
+      setIsPcSidebar(isPc)
+    }
+  }, [isPc, isTablet, tabletMode])
+
   return (
-    <Box sx={isPc ? style.pcNavBar : style.mobileNavBar}>
-      {isPc && (
+    <Box sx={isPcSidebar ? style.pcNavBar : style.mobileNavBar}>
+      {isPcSidebar && (
         <Stack
           direction={'row'}
           justifyContent={'flex-start'}
@@ -68,7 +89,7 @@ const CuNavBar = ({
         </Stack>
       )}
       <ToggleButtonGroup
-        orientation={isPc ? 'vertical' : 'horizontal'}
+        orientation={isPcSidebar ? 'vertical' : 'horizontal'}
         fullWidth={false}
         value={value}
         sx={style.tabs}
@@ -77,7 +98,7 @@ const CuNavBar = ({
           if (newValue) setValue(newValue)
         }}
       >
-        {isPc
+        {isPcSidebar
           ? [
               tabData.map((tab) => (
                 <PcToggleButton
@@ -93,7 +114,7 @@ const CuNavBar = ({
                   key={crypto.randomUUID()}
                   tab={tab}
                   selected={value === tab.value}
-                  width={90 / tabData.length}
+                  width={(tabletMode ? 180 : 90) / tabData.length}
                 />
               )),
             ]}
@@ -101,6 +122,7 @@ const CuNavBar = ({
     </Box>
   )
 }
+
 const PcToggleButton = ({
   tab,
   selected,
@@ -108,14 +130,15 @@ const PcToggleButton = ({
   tab: ITabInfo
   selected: boolean
 }) => {
-  const isNewTab = tab.new && !tab.disabled
   return (
     <ToggleButton
       value={tab.value}
       onClick={tab.onClick}
       sx={{
         ...style.pcTab,
-        ...(isNewTab || tab.isBeta ? style.newTab : undefined),
+        ...(tab.isNew || tab.isBeta || tab.isSoon
+          ? style.tabWithBadge
+          : undefined),
       }}
       disabled={tab.disabled}
       selected={selected}
@@ -128,16 +151,17 @@ const PcToggleButton = ({
         justifyContent={'center'}
       >
         <Typography variant={'Caption'}>{tab.label}</Typography>
-        {isNewTab && (
-          <Typography sx={style.newTextBadge} variant={'Caption'}>
-            NEW
-          </Typography>
-        )}
-        {tab.isBeta && <BetaIcon sx={{ paddingLeft: '0.5rem' }} />}
+        <PcButtonBadge
+          isNew={tab.isNew}
+          isBeta={tab.isBeta}
+          isSoon={tab.isSoon}
+          disabled={tab.disabled}
+        />
       </Stack>
     </ToggleButton>
   )
 }
+
 const MobileToggleButton = ({
   tab,
   selected,
@@ -147,7 +171,6 @@ const MobileToggleButton = ({
   selected: boolean
   width: number
 }) => {
-  const isNewTab = tab.new && !tab.disabled
   return (
     <ToggleButton
       value={tab.value}
@@ -157,16 +180,87 @@ const MobileToggleButton = ({
       selected={selected}
     >
       <Stack direction={'column'} spacing={'0.12rem'} alignItems={'center'}>
-        <Badge
-          sx={isNewTab ? style.newBadge : style.betaBadge}
-          variant={'dot'}
-          invisible={!isNewTab && !tab.isBeta}
+        <MobileButtonBadge
+          isNew={tab.isNew}
+          isBeta={tab.isBeta}
+          isSoon={tab.isSoon}
+          disabled={tab.disabled}
         >
           <Box sx={style.iconBoxBase}>{tab.icon}</Box>
-        </Badge>
+        </MobileButtonBadge>
         <Typography variant={'Tag'}>{tab.mobileLabel ?? tab.label}</Typography>
       </Stack>
     </ToggleButton>
+  )
+}
+
+const PcButtonBadge = ({
+  isNew,
+  isBeta,
+  isSoon,
+  disabled,
+}: IButtonBadgeProps) => {
+  if (isNew) {
+    return (
+      <Typography
+        color={disabled ? 'text.disable' : 'yellow.strong'}
+        variant={'Caption'}
+        sx={style.textBadge}
+      >
+        NEW
+      </Typography>
+    )
+  }
+  if (isBeta) {
+    return <BetaIcon sx={{ paddingLeft: '0.5rem' }} />
+  }
+  if (isSoon) {
+    return (
+      <Typography
+        color={'text.disable'}
+        variant={'Caption'}
+        sx={style.textBadge}
+      >
+        SOON
+      </Typography>
+    )
+  }
+  return null
+}
+
+const getBadgeStyle = (
+  isNew?: boolean,
+  isBeta?: boolean,
+  isSoon?: boolean,
+  disabled?: boolean,
+) => {
+  if (disabled) return style.disabledBadge
+  if (isNew) return style.newBadge
+  if (isBeta) return style.betaBadge
+  if (isSoon) return style.soonBadge
+  return undefined
+}
+
+const MobileButtonBadge = ({
+  isNew,
+  isBeta,
+  isSoon,
+  disabled,
+  children,
+}: IButtonBadgeProps & {
+  children: ReactElement
+}) => {
+  const badgeStyle = getBadgeStyle(isNew, isBeta, isSoon, disabled)
+  const isInvisible = !isNew && !isBeta && !isSoon
+  return (
+    <Badge
+      sx={badgeStyle}
+      variant={'dot'}
+      invisible={isInvisible}
+      color={'primary'}
+    >
+      {children}
+    </Badge>
   )
 }
 

--- a/src/components/CuNavBar.tsx
+++ b/src/components/CuNavBar.tsx
@@ -201,9 +201,8 @@ const PcButtonBadge = ({
   if (isNew) {
     return (
       <Typography
-        color={disabled ? 'text.disable' : 'yellow.strong'}
         variant={'Caption'}
-        sx={style.textBadge}
+        sx={disabled ? style.disabledTextBadge : style.newTextBadge}
       >
         NEW
       </Typography>
@@ -215,9 +214,8 @@ const PcButtonBadge = ({
   if (isSoon) {
     return (
       <Typography
-        color={'text.disable'}
         variant={'Caption'}
-        sx={style.textBadge}
+        sx={disabled ? style.disabledTextBadge : style.soonTextBadge}
       >
         SOON
       </Typography>

--- a/src/components/CuNavBar.tsx
+++ b/src/components/CuNavBar.tsx
@@ -8,7 +8,6 @@ import {
   ToggleButtonGroup,
   ToggleButton,
   Badge,
-  useMediaQuery,
 } from '@mui/material'
 import useMedia from '@/hook/useMedia'
 import { ChevronLeft } from '@/icons'
@@ -51,8 +50,7 @@ const CuNavBar = ({
 }: ICuNavBarProps) => {
   const pathName = usePathname()
   const [value, setValue] = useState<string | undefined>(undefined)
-  const { isPc } = useMedia()
-  const isTablet = useMediaQuery('(min-width:480px) and (max-width:997px)') // TODO : useMedia에 추가하는 방안 고려해보기
+  const { isPc, isLargeTablet } = useMedia()
   const [isPcSidebar, setIsPcSidebar] = useState<boolean>(false)
 
   const setTabValue = useCallback(() => {
@@ -65,11 +63,11 @@ const CuNavBar = ({
 
   useEffect(() => {
     if (tabletMode) {
-      setIsPcSidebar(!isTablet && isPc)
+      setIsPcSidebar(!isLargeTablet && isPc)
     } else {
       setIsPcSidebar(isPc)
     }
-  }, [isPc, isTablet, tabletMode])
+  }, [isPc, isLargeTablet, tabletMode])
 
   return (
     <Box sx={isPcSidebar ? style.pcNavBar : style.mobileNavBar}>

--- a/src/components/NavBarBox.style.ts
+++ b/src/components/NavBarBox.style.ts
@@ -10,3 +10,8 @@ export const mobileNavBar: SxProps = {
   width: '100%',
   height: 'content-fit',
 }
+
+export const tabletNavBar: SxProps = {
+  width: '70%',
+  height: 'content-fit',
+}

--- a/src/hook/useMedia.tsx
+++ b/src/hook/useMedia.tsx
@@ -5,8 +5,9 @@ import { useMediaQuery } from '@mui/material'
 const useMedia = () => {
   const isPc = useMediaQuery('(min-width:480px)')
   const isTablet = useMediaQuery('(min-width:480px) and (max-width:700px)')
+  const isLargeTablet = useMediaQuery('(min-width:480px) and (max-width:997px)') // 팀 페이지 navBar에서 사용
 
-  return { isPc, isTablet }
+  return { isPc, isTablet, isLargeTablet }
 }
 
 export default useMedia


### PR DESCRIPTION
### 관련 이슈
- close #947
- close #945

### 작업 내용

<img width="217" alt="Screen_Shot 2024-02-14 03 02 07" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/e509db16-84ab-4b34-94f5-482815d7f3c3">
<img width="294" alt="Screen_Shot 2024-02-14 03 02 48" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/21df1202-b33a-4609-8b74-08515c67e66e">


#### 1. SOON 뱃지 추가

아직 구현되지 않은 피어로그 기능에 베타 뱃지는 어울리지 않다는 의견이 있어 아직 구현되지 않은 기능임을 표시하기 위한 SOON 뱃지를 사이드바에 추가했습니다.

#### 2. 사이드바 디자인 보완

1. 사라진 보라색과 아이콘 추가
     <img width="696" alt="Screen_Shot 2024-02-14 02 29 40" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/34abd6e9-ce16-44ee-8952-42c6722f47df">
2. 적용되지 않았던 new 뱃지 색 추가 (mui 테마에 적용된 버튼 색이 우선적으로 적용되었기 때문이었습니다. `!important`로 우선순위를 높여주는 방식으로 해결했습니다.)
3. 누락되었던 disabled 탭의 글자색 추가

#### 3. 팀 페이지 사이드바 리팩토링

#910 에서 추가된 팀 페이지에서 태블릿 화면 크기일 때 모바일 뷰 사이드바를 보여주는 기능을 `CuNavbar`의 옵션으로 옮겼습니다.

![Screen_Shot 2024-02-14 02 44 30](https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/e4f6a84a-84f6-4eaf-95bc-b49a1be29a91)
