### PR TITLE
[1.0.3 / C-SIGN] logout 함수 수정

### DIFF
--- a/src/states/useAuthStore.tsx
+++ b/src/states/useAuthStore.tsx
@@ -41,12 +41,15 @@ const useAuthStore = create<IAuthStore>((set) => {
       }))
     },
     logout: (isRefreshing) => {
+      console.log('isRefreshing: ', isRefreshing)
       if (authData.accessToken && !isRefreshing) {
         axios
           .get(`${API_URL}/api/v1/logout`, {
             headers: {
               Authorization: `Bearer ${authData.accessToken}`,
             },
+          }).catch(()=>{
+            // console.log('만료된 토큰') -- do nothing
           })
       }
       LocalStorage.removeItem('authData')

--- a/src/states/useAuthStore.tsx
+++ b/src/states/useAuthStore.tsx
@@ -41,14 +41,14 @@ const useAuthStore = create<IAuthStore>((set) => {
       }))
     },
     logout: (isRefreshing) => {
-      console.log('isRefreshing: ', isRefreshing)
-      if (authData.accessToken && !isRefreshing) {
+      if (authData.accessToken && isRefreshing === undefined) {
         axios
           .get(`${API_URL}/api/v1/logout`, {
             headers: {
               Authorization: `Bearer ${authData.accessToken}`,
             },
-          }).catch(()=>{
+          })
+          .catch(() => {
             // console.log('만료된 토큰') -- do nothing
           })
       }


### PR DESCRIPTION
- 이전에 했었던 예외처리에도 불구하고 logout함수에서 401 error가 발생할 수 있어서(로그아웃 버튼클릭시 토큰이 만료되어있다던지 등등..) catch문 추가했습니다.
resolves: #942 