### PR TITLE
[1.0.3/ADMIN] 어드민 공지 / 배너에서 예약된 글은 수정이 가능해야하고, 게제된 글은 수정이 불가능해야합니다. 

### DIFF
--- a/src/app/admin/announce/Announce.tsx
+++ b/src/app/admin/announce/Announce.tsx
@@ -720,7 +720,11 @@ const Announce = () => {
               </Button>
             ) : null}
             {writeMode === 'view' ? (
-              <Button variant={'contained'} onClick={() => onHandleEdit()}>
+              <Button
+                variant={'contained'}
+                onClick={() => onHandleEdit()}
+                disabled={getValues('announcementStatus') !== '예약' ? true : false}
+              >
                 수정
               </Button>
             ) : writeMode === 'edit' ? (

--- a/src/app/admin/banner/Banner.tsx
+++ b/src/app/admin/banner/Banner.tsx
@@ -708,7 +708,7 @@ const Banner = () => {
                 variant={'contained'}
                 onClick={() => onHandleEdit()}
                 disabled={
-                  getValues('bannerStatus') !== '예약 중' ? true : false
+                  getValues('bannerStatus') !== '예약' ? true : false
                 }
               >
                 수정


### PR DESCRIPTION
- 기능 문제 해결완료

#960 공지/배너 보기에서 예약 된 글의 수정이 안됨