### PR TITLE
[1.0.3 / C-MAIN] 메인 페이지에 쇼케이스 내용 없어도 이쁘게

### DIFF
--- a/src/app/panel/main-page/MainShowcase.tsx
+++ b/src/app/panel/main-page/MainShowcase.tsx
@@ -89,6 +89,7 @@ const MainShowcase = () => {
               overflow={'hidden'}
               textOverflow={'ellipsis'}
               m={'1rem'}
+              height={'5rem'}
             >
               {/* <Typography
                 color={'text'}
@@ -103,7 +104,10 @@ const MainShowcase = () => {
               >
                 {data.content[0].description}
               </Typography> */}
-              <DynamicToastViewer initialValue={data.content[0].description} />
+              <DynamicToastViewer
+                sx={{ height: '100%' }}
+                initialValue={data.content[0].description}
+              />
             </Stack>
           </Card>
         </Stack>


### PR DESCRIPTION
<img width="456" alt="image" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/8c83bcc6-cf83-4148-8a17-60bf77c60c8d">

검은 부분 고쳤습니다.