### PR TITLE
[PUBLIC] next/image 폴백이미지 에러시에만 보이도록 수정

### DIFF
--- a/src/components/CuPhotoBox.tsx
+++ b/src/components/CuPhotoBox.tsx
@@ -28,9 +28,11 @@ const CuPhotoBox = ({
         ...style,
         position: 'relative',
         margin: 0,
-        backgroundColor: '#ffffff',
-        border: '1px solid',
-        borderColor: 'line.alternative',
+        ...(error && {
+          backgroundColor: '#ffffff',
+          border: '1px solid',
+          borderColor: 'line.alternative',
+        }),
       }}
     >
       {src && !error && (


### PR DESCRIPTION
### 수정 사항 
1. next/image 폴백이미지 에러시에만 보이도록 수정하였습니다. 