### PR TITLE
[ 1.0.5 / J-TB ] 모집글 수정시 팀 인원 + 1 되는 이슈 그리고 아직도 기술스택이라고 표시되는 이슈

### DIFF
--- a/src/app/recruit/[id]/edit/page.tsx
+++ b/src/app/recruit/[id]/edit/page.tsx
@@ -99,7 +99,7 @@ const Page = ({ params }: { params: { id: string } }) => {
         roleList: data.type === 'PROJECT' ? data.roleList : null,
         interviewList: fieldToForm(data.interviewList),
         place: data.place,
-        max: data.type === 'PROJECT' ? null : Number(data.max),
+        max: data.type === 'PROJECT' ? null : Number(data.max) - 1,
         type: data.type,
       })
       .then((res) => {

--- a/src/app/recruit/[id]/panel/RecruitDetailContent.tsx
+++ b/src/app/recruit/[id]/panel/RecruitDetailContent.tsx
@@ -88,7 +88,7 @@ const RecruitDetailContent = ({
         )}
       </RecruitContentText>
       <RecruitContentText
-        label="기술스택"
+        label="관련 태그"
         icon={
           <Icon.TagIcon sx={{ ...style.iconStyleBase, color: 'text.normal' }} />
         }


### PR DESCRIPTION
모집 수정시에 팀 총인원 - 1 해서 보내주는걸로 변경

예를들어 10명을 모집한다고 햇을때
모집글 작성시에는 모집인원 10명이 되는것이고 (나 빼고)
모집글 수정시에는 팀의 총인원 11명이 오니까
수정완료시에는 11 - 1 = 10명을 다시 보내야한다.

### 태그 이름 기술스택에서 관련 태그로 변경
아직 반영 안된부분이 있어서 다시 수정