### PR TITLE
[1.0.6 / H-SC] 쇼케이스 대공사

### DIFF
--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -98,27 +98,13 @@ const Showcase = () => {
     )
   }
 
-  if (isTablet) {
-    return (
-      <Stack>
-        <CardContainer
-          cardList={cardList}
-          removeCard={removeCard}
-          message={message}
-          addCard={addCard}
-          addDisabled={draggedCardList.length === 0}
-          mutate={setCardList}
-        />
-      </Stack>
-    )
-  }
-
   return (
     <CardContainer
       cardList={cardList}
       removeCard={removeCard}
       message={message}
       addCard={addCard}
+      addDisabled={draggedCardList.length === 0}
       mutate={setCardList}
     />
   )

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -17,7 +17,7 @@ const Showcase = () => {
   const [page, setPage] = useState<number>(1)
   const [cardList, setCardList] = useState<Array<ICardData>>([])
   const [draggedCardList, setDraggedCardList] = useState<ICardData[]>([])
-  const { isPc } = useMedia()
+  const { isPc, isTablet } = useMedia()
   const { isLogin } = useAuthStore()
   const axiosWithAuth = useAxiosWithAuth()
   const { data, isLoading, error } = useSWR<IPagination<ICardData[]>>(
@@ -85,7 +85,7 @@ const Showcase = () => {
   else if (isLoading && !cardList.length) message = '로딩중'
   else if (error) message = '에러 발생'
 
-  if (isPc) {
+  if (isPc && !isTablet) {
     return (
       <Stack
         height={'100%'}
@@ -97,6 +97,21 @@ const Showcase = () => {
       </Stack>
     )
   }
+
+  if (isTablet) {
+    return (
+      <Stack>
+        <CardContainer
+          cardList={cardList}
+          removeCard={removeCard}
+          message={message}
+          addCard={addCard}
+          addDisabled={draggedCardList.length === 0}
+        />
+      </Stack>
+    )
+  }
+
   return (
     <CardContainer
       cardList={cardList}

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -107,6 +107,7 @@ const Showcase = () => {
           message={message}
           addCard={addCard}
           addDisabled={draggedCardList.length === 0}
+          mutate={setCardList}
         />
       </Stack>
     )
@@ -118,6 +119,7 @@ const Showcase = () => {
       removeCard={removeCard}
       message={message}
       addCard={addCard}
+      mutate={setCardList}
     />
   )
 }

--- a/src/app/showcase/panel/CardContainer.style.ts
+++ b/src/app/showcase/panel/CardContainer.style.ts
@@ -1,4 +1,10 @@
 import { SxProps } from '@mui/material'
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+})
 
 export const cardContainerStyleBase: SxProps = {
   width: '100%',
@@ -26,7 +32,7 @@ export const gnbContainerStyle: SxProps = {
 export const gnbTypographyStyle: SxProps = {
   color: 'text.normal',
   textAlign: 'center',
-  fontFamily: 'Inter',
+  fontFamily: `${inter.style.fontFamily} !important` as string,
   fontSize: '13px',
   fontStyle: 'normal',
   fontWeight: 700,

--- a/src/app/showcase/panel/CardContainer.tsx
+++ b/src/app/showcase/panel/CardContainer.tsx
@@ -76,7 +76,7 @@ const CardContainer = ({
         display={'flex'}
         justifyContent={'space-between'}
       >
-        {isTablet && isPc && (
+        <>
           <IconButton
             sx={style.buttonStyle}
             onClick={addCard}
@@ -86,8 +86,6 @@ const CardContainer = ({
               sx={{ ...style.buttonIconStyle, color: 'text.alternative' }}
             />
           </IconButton>
-        )}
-        {isTablet && isPc && (
           <IconButton
             sx={style.buttonStyle}
             onClick={() => removeCard(cardList[cardList.length - 1]?.id)}
@@ -97,7 +95,7 @@ const CardContainer = ({
               sx={{ ...style.buttonIconStyle, color: 'text.alternative' }}
             />
           </IconButton>
-        )}
+        </>
       </Stack>
     </Stack>
   )

--- a/src/app/showcase/panel/CardContainer.tsx
+++ b/src/app/showcase/panel/CardContainer.tsx
@@ -1,36 +1,39 @@
 'use client'
+
 import React from 'react'
 import useMedia from '@/hook/useMedia'
-import { Stack, Typography } from '@mui/material'
-import * as cardStyle from './ShowcaseCard.style'
+import { IconButton, Stack, Typography } from '@mui/material'
 import * as containerStyle from './CardContainer.style'
+import * as style from '../showcase.style'
 import CardStack from './CardStack'
 import { ICardData } from '@/app/showcase/panel/types'
 import { BetaIcon } from '@/components/BetaBadge'
+import { ChevronLeft, ChevronRight } from '@/icons'
 
 const CardContainer = ({
   cardList,
   removeCard,
   message,
   addCard,
+  addDisabled,
 }: {
   cardList: Array<ICardData>
   removeCard: (recruit_id: number) => void
   message: string
   addCard?: () => void
+  addDisabled?: boolean
 }) => {
-  const { isPc } = useMedia()
+  const { isPc, isTablet } = useMedia()
   return (
     <Stack
       justifyContent={'center'}
       alignItems={'center'}
       sx={
-        isPc
+        isPc && !isTablet
           ? containerStyle.cardContainerPCStyle
           : containerStyle.cardContainerMobileStyle
       }
       direction={'column'}
-      spacing={'2rem'}
     >
       <Stack
         direction={'row'}
@@ -48,8 +51,10 @@ const CardContainer = ({
         justifyContent={'center'}
         alignItems={'center'}
         sx={{
-          ...(isPc ? cardStyle.cardPcSize : cardStyle.cardMobileSize),
+          mb: '0.875rem',
           position: 'relative',
+          zIndex: 100,
+          flexGrow: [1, 0],
         }}
       >
         {!message ? (
@@ -60,6 +65,35 @@ const CardContainer = ({
           />
         ) : (
           <Typography variant="CaptionEmphasis">{message}</Typography>
+        )}
+      </Stack>
+      <Stack
+        direction={'row'}
+        width={'30%'}
+        display={'flex'}
+        justifyContent={'space-between'}
+      >
+        {isTablet && isPc && (
+          <IconButton
+            sx={style.buttonStyle}
+            onClick={addCard}
+            disabled={!!addDisabled}
+          >
+            <ChevronLeft
+              sx={{ ...style.buttonIconStyle, color: 'text.alternative' }}
+            />
+          </IconButton>
+        )}
+        {isTablet && isPc && (
+          <IconButton
+            sx={style.buttonStyle}
+            onClick={() => removeCard(cardList[cardList.length - 1]?.id)}
+            disabled={cardList.length === 1}
+          >
+            <ChevronRight
+              sx={{ ...style.buttonIconStyle, color: 'text.alternative' }}
+            />
+          </IconButton>
         )}
       </Stack>
     </Stack>

--- a/src/app/showcase/panel/CardContainer.tsx
+++ b/src/app/showcase/panel/CardContainer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { Dispatch, SetStateAction } from 'react'
 import useMedia from '@/hook/useMedia'
 import { IconButton, Stack, Typography } from '@mui/material'
 import * as containerStyle from './CardContainer.style'
@@ -16,12 +16,14 @@ const CardContainer = ({
   message,
   addCard,
   addDisabled,
+  mutate,
 }: {
   cardList: Array<ICardData>
   removeCard: (recruit_id: number) => void
   message: string
   addCard?: () => void
   addDisabled?: boolean
+  mutate: Dispatch<SetStateAction<ICardData[]>>
 }) => {
   const { isPc, isTablet } = useMedia()
   return (
@@ -62,6 +64,7 @@ const CardContainer = ({
             cardList={cardList}
             removeCard={removeCard}
             addCard={addCard}
+            mutate={mutate}
           />
         ) : (
           <Typography variant="CaptionEmphasis">{message}</Typography>

--- a/src/app/showcase/panel/CardStack.tsx
+++ b/src/app/showcase/panel/CardStack.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box } from '@mui/material'
-import React, { useState } from 'react'
+import React, { Dispatch, SetStateAction, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import * as style from './ShowcaseCard.style'
 import { ICardData } from '@/app/showcase/panel/types'
@@ -18,10 +18,12 @@ const CardStack = ({
   cardList,
   removeCard,
   addCard,
+  mutate,
 }: {
   cardList: Array<ICardData>
   removeCard: (recruit_id: number) => void
   addCard?: () => void
+  mutate: Dispatch<SetStateAction<ICardData[]>>
 }) => {
   const [dragged, setDragged] = useState(false)
 
@@ -119,6 +121,7 @@ const CardStack = ({
                   data={card}
                   dragged={dragged}
                   setDragged={setDragged}
+                  mutate={mutate}
                 />
               </motion.div>
             )

--- a/src/app/showcase/panel/CardStack.tsx
+++ b/src/app/showcase/panel/CardStack.tsx
@@ -4,7 +4,6 @@ import { Box } from '@mui/material'
 import React, { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import * as style from './ShowcaseCard.style'
-import useMedia from '@/hook/useMedia'
 import { ICardData } from '@/app/showcase/panel/types'
 import { ShowcaseCard } from './ShowcaseCard'
 
@@ -25,7 +24,6 @@ const CardStack = ({
   addCard?: () => void
 }) => {
   const [dragged, setDragged] = useState(false)
-  const { isPc } = useMedia()
 
   const checkDragDirection = (x: number, y: number) => {
     return y < 0 ? ESwipeDirection.up : ESwipeDirection.down
@@ -51,10 +49,7 @@ const CardStack = ({
 
   return (
     <>
-      <Box
-        position={'relative'}
-        sx={isPc ? style.cardPcSize : style.cardMobileSize}
-      >
+      <Box position={'relative'} sx={style.cardSize}>
         <motion.div
           animate={{
             opacity: cardList.length > 1 ? 1 : 0,
@@ -65,7 +60,7 @@ const CardStack = ({
         >
           <Box
             sx={{
-              ...(isPc ? style.cardPcSize : style.cardMobileSize),
+              ...style.cardSize,
               backgroundColor: 'text.assistive',
             }}
           />
@@ -80,7 +75,7 @@ const CardStack = ({
         >
           <Box
             sx={{
-              ...(isPc ? style.cardPcSize : style.cardMobileSize),
+              ...style.cardSize,
               backgroundColor: 'text.assistive',
             }}
           />
@@ -122,7 +117,6 @@ const CardStack = ({
               >
                 <ShowcaseCard
                   data={card}
-                  sx={isPc ? style.cardPcStyleBase : style.cardMobileStyleBase}
                   dragged={dragged}
                   setDragged={setDragged}
                 />

--- a/src/app/showcase/panel/PhoneFrame.tsx
+++ b/src/app/showcase/panel/PhoneFrame.tsx
@@ -6,11 +6,13 @@ const PhoneFrame = ({ imageUrl }: { imageUrl: string | undefined }) => {
     <Stack alignItems={'center'} justifyContent={'center'}>
       <Box
         position={'relative'}
-        component={'img'}
-        src="/images/iPhoneMock.svg"
         sx={{
-          width: '22.5rem',
+          width: '17rem',
           height: '40rem',
+          borderColor: 'text.normal',
+          borderStyle: 'solid',
+          borderWidth: 2,
+          borderRadius: '3rem',
         }}
       />
       <Stack
@@ -24,7 +26,7 @@ const PhoneFrame = ({ imageUrl }: { imageUrl: string | undefined }) => {
             src={imageUrl}
             sx={{
               width: '16rem',
-              height: '40rem',
+              height: '20rem',
               objectFit: 'contain',
             }}
           />
@@ -32,8 +34,9 @@ const PhoneFrame = ({ imageUrl }: { imageUrl: string | undefined }) => {
           <Box
             display={'flex'}
             sx={{
-              width: '22.5rem',
+              width: '20rem',
               height: '40rem',
+              objectFit: 'contain',
             }}
             alignItems={'center'}
             justifyContent={'center'}

--- a/src/app/showcase/panel/PostCard.style.ts
+++ b/src/app/showcase/panel/PostCard.style.ts
@@ -1,5 +1,15 @@
 import { SxProps } from '@mui/material'
 
+export const cardSubtitleStyleBase: SxProps = {
+  width: '100%',
+  overflow: 'hidden',
+  lineHeight: '21px',
+  textOverflow: 'ellipsis',
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 1,
+}
+
 export const cardTitleStyleBase: SxProps = {
   width: '100%',
   overflow: 'hidden',
@@ -13,10 +23,16 @@ export const cardMediaStyleBase: SxProps = {
   flexGrow: 1,
   objectFit: 'cover',
   maxHeight: '15.6875rem',
+  width: ['calc(90svh * 328 / 800)', 'calc(80svh * 328 /800)'],
+  height: ['calc(90svh * 251 / 800)', 'calc(80svh * 251 /800)'],
+  p: 0,
+  boxSizing: 'border-box',
 }
 
 export const cardAuthorAvatarStyleBase: SxProps = {
   maxWidth: '2rem',
   maxHeight: '2rem',
   boxSizing: 'border-box',
+  height: ['calc(90svh * 32 / 800)', 'calc(80svh * 32 /800)'],
+  width: ['calc(90svh * 32 / 800)', 'calc(80svh * 32 /800)'],
 }

--- a/src/app/showcase/panel/PostCard.tsx
+++ b/src/app/showcase/panel/PostCard.tsx
@@ -3,7 +3,6 @@ import {
   Card,
   CardContent,
   CardHeader,
-  CardMedia,
   IconButton,
   Stack,
   Typography,
@@ -18,6 +17,7 @@ import { IShowcaseTag } from './types'
 import useAxiosWithAuth from '@/api/config'
 import FavoriteIcon from '@mui/icons-material/Favorite'
 import ThumbUpIcon from '@mui/icons-material/ThumbUp'
+import CuPhotoBox from '@/components/CuPhotoBox'
 
 function PostCard({
   postId,
@@ -62,6 +62,7 @@ function PostCard({
           setFavorite(!favorite)
         }
       })
+      .catch(() => {})
   }, [setFavorite, axiosWithAuth])
 
   const clickLike = useCallback(() => {
@@ -78,6 +79,7 @@ function PostCard({
           }
         }
       })
+      .catch(() => {})
   }, [setIsLiked, setLikeNum, axiosWithAuth])
 
   return (
@@ -89,17 +91,15 @@ function PostCard({
         backfaceVisibility: 'hidden',
       }}
       ref={ref}
-      onClick={onClick}
     >
-      <CardMedia
-        component="img"
-        image={image ? image : '/icons/52.png'}
-        alt="post thumbnail"
-        sx={{
-          ...style.cardMediaStyleBase,
-          height: (currentCardWidth * 251) / 328,
-        }}
-      />
+      <CardContent sx={style.cardMediaStyleBase} onClick={onClick}>
+        <CuPhotoBox
+          src={image ? image : '/icons/52.png'}
+          alt="post thumbnail"
+          style={{ width: '100%', height: '100%', boxSizing: 'border-box' }}
+        />
+      </CardContent>
+
       <Stack
         sx={{ p: '1rem', pt: '0.75rem' }}
         spacing={'15px'}
@@ -160,6 +160,7 @@ function PostCard({
             height: (currentCardWidth * 190) / 328,
             boxSizing: 'border-box',
           }}
+          onClick={onClick}
         >
           <CardContent sx={{ p: 0 }}>
             <Typography

--- a/src/app/showcase/panel/ShowcaseCard.style.ts
+++ b/src/app/showcase/panel/ShowcaseCard.style.ts
@@ -1,24 +1,16 @@
 import { SxProps } from '@mui/material'
 
-export const cardSizeBase: SxProps = {
+export const cardSize: SxProps = {
+  boxSizing: 'border-box',
   maxHeight: '441px',
   maxWidth: '20.5rem',
   borderRadius: '0.75rem',
-}
-
-export const cardPcSize: SxProps = {
-  ...cardSizeBase,
-  width: 'calc(80svh * 328 /800)',
-  height: 'calc(80svh * 441 /800)',
-}
-
-export const cardMobileSize: SxProps = {
-  ...cardSizeBase,
-  width: '90vw',
-  height: 'calc(90vw * 441 / 328)',
+  width: ['calc(90svh * 328 / 800)', 'calc(80svh * 328 /800)'],
+  height: ['calc(90svh * 441 / 800)', 'calc(80svh * 441 /800)'],
 }
 
 export const cardStyleBase: SxProps = {
+  ...cardSize,
   backgroundColor: 'background.primary',
   borderWidth: '2px',
   borderColor: 'line.base',
@@ -26,19 +18,7 @@ export const cardStyleBase: SxProps = {
   position: 'absolute',
   top: '50%',
   left: '50%',
-  boxSizing: 'border-box',
 }
-
-export const cardPcStyleBase: SxProps = {
-  ...cardStyleBase,
-  ...cardPcSize,
-}
-
-export const cardMobileStyleBase: SxProps = {
-  ...cardStyleBase,
-  ...cardMobileSize,
-}
-
 export const cardTitleStyleBase: SxProps = {
   width: '100%',
   overflow: 'hidden',
@@ -59,14 +39,22 @@ export const cardChipStyleBase: SxProps = {
   },
 }
 
+export const cardHeaderStyleBase: SxProps = {
+  height: '2.5rem',
+  width: '100%',
+}
+
 export const cardContentStyleBase: SxProps = {
   width: '100%',
   overflow: 'hidden',
-  maxHeight: '11.25rem',
+  height: '7rem',
   lineHeight: '1.125rem',
   textOverflow: 'ellipsis',
   WebkitBoxOrient: 'vertical',
   display: '-webkit-box',
+  flex: '1 0 auto',
+  padding: 0,
+  backgroundColor: 'transparent',
 }
 
 export const cardMoreButtonStyle: SxProps = {

--- a/src/app/showcase/panel/ShowcaseCard.tsx
+++ b/src/app/showcase/panel/ShowcaseCard.tsx
@@ -15,7 +15,13 @@ import {
   Box,
 } from '@mui/material'
 import { useRouter } from 'next/navigation'
-import React, { useEffect, useRef, useState } from 'react'
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import DropdownMenu from '@/components/DropdownMenu'
 import * as style from './ShowcaseCard.style'
 import { ICardData } from '@/app/showcase/panel/types'
@@ -237,11 +243,13 @@ const ShowcaseCard = ({
   data,
   dragged,
   setDragged,
+  mutate,
 }: {
   data: ICardData
   sx?: SxProps
   dragged: boolean
   setDragged: React.Dispatch<React.SetStateAction<boolean>>
+  mutate: Dispatch<SetStateAction<ICardData[]>>
 }) => {
   const [isFlipped, setIsFlipped] = useState(false)
   const [currentDomain, setCurrentDomain] = useState('')
@@ -285,6 +293,7 @@ const ShowcaseCard = ({
           transform: 'translate(-50%, 0)',
         }}
         onClick={handleMouseUp}
+        mutate={mutate}
       />
       <ShowcaseCardBack
         postId={data.id}

--- a/src/states/useShowcaseCardStore.tsx
+++ b/src/states/useShowcaseCardStore.tsx
@@ -1,0 +1,60 @@
+import { ICardData } from '@/app/showcase/panel/types'
+import { create } from 'zustand'
+
+import axios from 'axios'
+
+interface IShowcaseStore {
+  showcases: ICardData[]
+  draggedCardList: ICardData[]
+  page: number
+  index: number
+  setShowcases: (showcases: ICardData[]) => void
+  setDraggedCardList: (draggedCardList: ICardData[]) => void
+  getShowcases: (page: number) => void
+  removeShowcase: () => void
+  nextShowcase: () => void
+  prevShowcase: () => void
+  resetShowcases: () => void
+}
+
+const useShowcaseStore = create<IShowcaseStore>((set, get) => {
+  return {
+    showcases: [],
+    draggedCardList: [],
+    page: 1,
+    index: 0,
+    setShowcases: (showcases: ICardData[]) => {
+      set(() => ({ showcases: showcases }))
+    },
+    setDraggedCardList: (draggedCardList: ICardData[]) => {
+      set(() => ({ draggedCardList: draggedCardList }))
+    },
+
+    getShowcases: (page: number) => {
+      axios
+        .get(
+          `${process.env.NEXT_PUBLIC_CSR_API}/api/v1/showcase?page=${page}&pageSize=10`,
+        )
+        .then((res) => {
+          const oldShowcases = get().showcases
+          const newShowcases = [...oldShowcases]
+            .reverse()
+            .concat(res.data.content)
+          set(() => ({ showcases: newShowcases, page: page }))
+        })
+    },
+
+    removeShowcase: () => {
+      const oldShowcases = get().showcases
+      const oldLength = oldShowcases.length
+      if (oldShowcases.length > 1) {
+        oldShowcases.push(oldShowcases[oldLength - 1])
+      }
+    },
+    nextShowcase: () => {},
+    prevShowcase: () => {},
+    resetShowcases: () => {},
+  }
+})
+
+export default useShowcaseStore

--- a/src/types/IPostCard.ts
+++ b/src/types/IPostCard.ts
@@ -1,6 +1,7 @@
 import { SxProps } from '@mui/material'
 import { ITag } from './IPostDetail'
-import { IShowcaseTag } from '@/app/showcase/panel/types'
+import { ICardData, IShowcaseTag } from '@/app/showcase/panel/types'
+import { Dispatch, SetStateAction } from 'react'
 
 export interface IPostCard {
   authorImage: string // 글 작성자 프로필 이미지
@@ -36,6 +37,7 @@ export interface IPostCardShowcase {
   liked: boolean
   sx?: SxProps
   onClick?: (e: React.MouseEvent) => void
+  mutate: Dispatch<SetStateAction<ICardData[]>>
 }
 
 export interface IHitchhikingCardBack {


### PR DESCRIPTION
## 변경사항

1. 휴대폰 목업 변경

<img width="1066" alt="image" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/4231062a-5962-4090-9b11-25d445099b50">

2. 이미지 404에 대한 대처

<img width="531" alt="image" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/fb2617cd-2197-415c-b177-dce067373483">

3. 태블릿 뷰 대응

<img width="531" alt="image" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/e62dca7b-df19-4d91-b857-aefcba27e905">

4. 모바일 화면에서 하단 버튼 추가

<img width="531" alt="image" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/f611af49-342b-4c8c-8837-a9826a5f986e">

5. 좋아요와 관심 추가 버그 수정
6. 긴 내용이 들어올 때의 대응 (Thanks to Hyna)
