### PR TITLE
[1.0.6 / D-TP] 팀 게시판 제목 표기 오류 수정

### DIFF
--- a/src/app/teams/[id]/board/@detail/page.tsx
+++ b/src/app/teams/[id]/board/@detail/page.tsx
@@ -56,6 +56,7 @@ const TeamBoardPostView = ({ params }: { params: { id: string } }) => {
   if (!data || error)
     return (
       <StatusMessage
+        boardType={'BOARD'}
         message={'문제가 발생했습니다.'}
         onClickEditButton={() => setBoard('LIST', boardId, postId)}
         author={!!data?.isAuthor}
@@ -64,6 +65,7 @@ const TeamBoardPostView = ({ params }: { params: { id: string } }) => {
   if (isLoading)
     return (
       <StatusMessage
+        boardType={'BOARD'}
         message={'게시글을 불러오는 중입니다...'}
         onClickEditButton={() => setBoard('LIST', boardId, postId)}
         author={!!data?.isAuthor}
@@ -71,7 +73,7 @@ const TeamBoardPostView = ({ params }: { params: { id: string } }) => {
     )
   return (
     <>
-      <DetailPage handleGoBack={handleGoBack}>
+      <DetailPage boardType={'BOARD'} handleGoBack={handleGoBack}>
         {isPc && (
           <CuButton
             message={'이전 페이지'}

--- a/src/app/teams/[id]/notice/@detail/page.tsx
+++ b/src/app/teams/[id]/notice/@detail/page.tsx
@@ -53,6 +53,7 @@ const TeamNoticeView = ({ params }: { params: { id: string } }) => {
   if (!data || error)
     return (
       <StatusMessage
+        boardType={'NOTICE'}
         message={'문제가 발생했습니다.'}
         onClickEditButton={() => setNotice('EDIT', postId)}
         author={!!data?.isAuthor}
@@ -61,6 +62,7 @@ const TeamNoticeView = ({ params }: { params: { id: string } }) => {
   if (isLoading)
     return (
       <StatusMessage
+        boardType={'NOTICE'}
         message={'공지사항을 불러오는 중입니다...'}
         onClickEditButton={() => setNotice('EDIT', postId)}
         author={!!data?.isAuthor}
@@ -68,7 +70,7 @@ const TeamNoticeView = ({ params }: { params: { id: string } }) => {
     )
   return (
     <>
-      <DetailPage handleGoBack={handleGoBack}>
+      <DetailPage boardType={'NOTICE'} handleGoBack={handleGoBack}>
         {isPc && (
           <CuButton
             message={'이전 페이지'}

--- a/src/components/board/DetailPanel.tsx
+++ b/src/components/board/DetailPanel.tsx
@@ -6,6 +6,8 @@ import CuModal from '../CuModal'
 import DynamicToastViewer from '../DynamicToastViewer'
 import * as style from './DetailPanel.style'
 
+type TBoardType = 'NOTICE' | 'BOARD'
+
 interface IChildrenProps {
   children: React.ReactNode
 }
@@ -18,10 +20,12 @@ interface IDetailContentContainerProps {
 }
 
 interface IDetailPageProps extends IChildrenProps {
+  boardType: TBoardType
   handleGoBack: () => void
 }
 
 interface IStatusMessageProps {
+  boardType: TBoardType
   message: string
   onClickEditButton?: () => void
   author: boolean
@@ -34,7 +38,16 @@ interface IDetailContentProps {
   content: string
 }
 
-export const DetailPage = ({ children, handleGoBack }: IDetailPageProps) => {
+const title: Record<TBoardType, string> = {
+  NOTICE: '공지사항',
+  BOARD: '게시글',
+}
+
+export const DetailPage = ({
+  children,
+  boardType,
+  handleGoBack,
+}: IDetailPageProps) => {
   const { isPc } = useMedia()
   if (isPc) {
     return (
@@ -46,7 +59,7 @@ export const DetailPage = ({ children, handleGoBack }: IDetailPageProps) => {
   return (
     <CuModal
       open={true}
-      title={'공지사항'}
+      title={title[boardType]}
       onClose={handleGoBack}
       mobileFullSize
     >
@@ -89,13 +102,14 @@ export const DetailContentCotainer = ({
 }
 
 export const StatusMessage = ({
+  boardType,
   message,
   onClickEditButton,
   author,
 }: IStatusMessageProps) => {
   return (
     <DetailContentCotainer
-      containerTitle={'공지사항'}
+      containerTitle={title[boardType]}
       onClickEditButton={onClickEditButton}
       author={author}
     >


### PR DESCRIPTION
### 관련 이슈

- close #1056

### 작업 내용

정적으로 보여주던 페이지 제목을 타입에 따라 공지사항과 게시글로 보여줄 수 있게 수정했습니다.

<img width="40%" alt="Screen_Shot 2024-02-17 23 22 05" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/1cd71dfd-b8b0-4573-be7c-ec71c50c3941">
<img width="40%" alt="Screen_Shot 2024-02-17 23 21 49" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/124dbaf6-57c3-4baa-9df5-2d629ba918f4">
