### PR TITLE
[1.0.6 / D-TP] 팀 페이지 게시판 댓글 버그 수정

### DIFF
--- a/src/components/board/CommentForm.tsx
+++ b/src/components/board/CommentForm.tsx
@@ -20,11 +20,17 @@ export const CommentForm = ({ postId, teamId }: ICommentFormProps) => {
     e.preventDefault()
     setIsLoading(true)
     const formData = new FormData(e.currentTarget)
+    const content = formData.get('new-content') as string
+    if (!content) {
+      setIsLoading(false)
+      openToast({ severity: 'error', message: '댓글을 입력해주세요.' })
+      return
+    }
     axiosWithAuth
       .post('/api/v1/team/post/comment/', {
         teamId: teamId,
         postId: postId,
-        content: formData.get('new-content') as string,
+        content,
       })
       .then(() => {
         setIsLoading(false)

--- a/src/components/board/CommentList.tsx
+++ b/src/components/board/CommentList.tsx
@@ -28,6 +28,11 @@ const Comment = ({ comment, postId }: ICommentProps) => {
   const handleEdit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const formData = new FormData(e.currentTarget)
+    const content = formData.get('content') as string
+    if (!content) {
+      openToast({ severity: 'error', message: '댓글을 입력해주세요.' })
+      return
+    }
     axiosWithAuth
       .put(`/api/v1/team/post/comment/${comment.answerId}`, {
         content: formData.get('content') as string,

--- a/src/components/board/CommentList.tsx
+++ b/src/components/board/CommentList.tsx
@@ -35,7 +35,7 @@ const Comment = ({ comment, postId }: ICommentProps) => {
     }
     axiosWithAuth
       .put(`/api/v1/team/post/comment/${comment.answerId}`, {
-        content: formData.get('content') as string,
+        content,
       })
       .then(() => {
         openToast({ severity: 'success', message: '댓글을 수정했습니다.' })

--- a/src/components/board/CommentPanel.tsx
+++ b/src/components/board/CommentPanel.tsx
@@ -219,7 +219,7 @@ export const CommentItem = ({
             </Stack>
           </form>
         ) : (
-          <Box sx={{ paddingRight: '2.5rem' }}>
+          <Box sx={{ paddingRight: '2.5rem', wordBreak: 'break-all' }}>
             <Typography variant={'Body2'}>{comment.content}</Typography>
             <Typography variant={'Tag'} color={'text.assistive'}>
               {dayjs(comment.createdAt).format('YYYY년 M월 D일 h:m A')}


### PR DESCRIPTION
### 관련 이슈

- close #1065
- close #1066 

### 작업 내용

#### 빈 댓글 버그 수정
공지사항과 팀 페이지 댓글에 빈 댓글을 달 수 있었던 문제를 해결했습니다.
새 댓글 작성과 댓글 수정 모두에 빈 content의 경우 경고 toast를 띄우도록 했습니다.

#### 레이아웃 깨짐 수정
영어의 경우 줄바꿈이 되지 않던 문제를 수정했습니다. (word break 속성이 빠져있던 것이 원인이었음)

<img width="563" alt="Screen_Shot 2024-02-21 15 34 14" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/8f3c8986-fc83-4ee7-886c-d75fd6364f82">

