### PR TITLE
[1.0.6 / D-TP] 댓글 일자 표시 버그 수정

### DIFF
--- a/src/components/board/CommentList.tsx
+++ b/src/components/board/CommentList.tsx
@@ -35,7 +35,7 @@ const Comment = ({ comment, postId }: ICommentProps) => {
     }
     axiosWithAuth
       .put(`/api/v1/team/post/comment/${comment.commentId}`, {
-        content: formData.get('content') as string,
+        content,
       })
       .then(() => {
         openToast({ severity: 'success', message: '댓글을 수정했습니다.' })

--- a/src/components/board/CommentList.tsx
+++ b/src/components/board/CommentList.tsx
@@ -9,7 +9,7 @@ import {
   CommentItem,
 } from '@/components/board/CommentPanel'
 import useToast from '@/states/useToast'
-import { ITeamBoardComment, ITeamComment } from '@/types/TeamBoardTypes'
+import { ITeamComment } from '@/types/TeamBoardTypes'
 import CuTextModal from '../CuTextModal'
 import useModal from '@/hook/useModal'
 
@@ -29,7 +29,7 @@ const Comment = ({ comment, postId }: ICommentProps) => {
     e.preventDefault()
     const formData = new FormData(e.currentTarget)
     axiosWithAuth
-      .put(`/api/v1/team/post/comment/${comment.answerId}`, {
+      .put(`/api/v1/team/post/comment/${comment.commentId}`, {
         content: formData.get('content') as string,
       })
       .then(() => {
@@ -44,7 +44,7 @@ const Comment = ({ comment, postId }: ICommentProps) => {
 
   const handleDelete = () => {
     axiosWithAuth
-      .delete(`/api/v1/team/post/comment/${comment.answerId}`)
+      .delete(`/api/v1/team/post/comment/${comment.commentId}`)
       .then(() => {
         openToast({ severity: 'success', message: '댓글을 삭제했습니다.' })
         mutate(`/api/v1/team/post/comment/${postId}`) // 댓글 데이터 만료
@@ -102,20 +102,11 @@ const CommentList = ({ postId }: { postId: number }) => {
   return (
     <Stack>
       <CommentContainer>
-        {data.map((comment: ITeamBoardComment) => {
-          // TODO : notice와 댓글 타입 통일 필요함....
-          const transformComment: ITeamComment = {
-            answerId: comment.commentId,
-            authorImage: comment.authorImage,
-            authorNickname: comment.authorNickname,
-            content: comment.content,
-            createdAt: comment.createdAt,
-            isAuthor: comment.isAuthor,
-          }
+        {data.map((comment: ITeamComment) => {
           return (
             <Comment
               key={comment.commentId}
-              comment={transformComment}
+              comment={comment}
               postId={postId}
             />
           )

--- a/src/components/board/CommentPanel.tsx
+++ b/src/components/board/CommentPanel.tsx
@@ -222,7 +222,7 @@ export const CommentItem = ({
           <Box sx={{ paddingRight: '2.5rem' }}>
             <Typography variant={'Body2'}>{comment.content}</Typography>
             <Typography variant={'Tag'} color={'text.assistive'}>
-              {dayjs(comment.createAt).format('YYYY년 M월 D일 h:m A')}
+              {dayjs(comment.createAt).format('YYYY년 MM월 DD일 hh:mm A')}
             </Typography>
           </Box>
         )}

--- a/src/components/board/CommentPanel.tsx
+++ b/src/components/board/CommentPanel.tsx
@@ -186,7 +186,7 @@ export const CommentItem = ({
           </Stack>
           {!isEditMode && canEdit ? (
             <CommentMoreDropdownMenu
-              handleDelete={() => handleDelete(comment.answerId)}
+              handleDelete={() => handleDelete(comment.commentId)}
               setEditMode={() => setEditMode(true)}
             />
           ) : (
@@ -222,7 +222,7 @@ export const CommentItem = ({
           <Box sx={{ paddingRight: '2.5rem' }}>
             <Typography variant={'Body2'}>{comment.content}</Typography>
             <Typography variant={'Tag'} color={'text.assistive'}>
-              {dayjs(comment.createdAt).format('YYYY년 M월 D일 h:m A')}
+              {dayjs(comment.createAt).format('YYYY년 M월 D일 h:m A')}
             </Typography>
           </Box>
         )}

--- a/src/components/board/CommentPanel.tsx
+++ b/src/components/board/CommentPanel.tsx
@@ -15,6 +15,7 @@ import { ITeamComment } from '@/types/TeamBoardTypes'
 import CuAvatar from '../CuAvatar'
 import CuButton from '../CuButton'
 import * as style from './CommentPanel.style'
+import UTCtoLocalTime from '@/utils/UTCtoLocalTime'
 
 interface IChildrenProps {
   children: React.ReactNode
@@ -222,7 +223,9 @@ export const CommentItem = ({
           <Box sx={{ paddingRight: '2.5rem' }}>
             <Typography variant={'Body2'}>{comment.content}</Typography>
             <Typography variant={'Tag'} color={'text.assistive'}>
-              {dayjs(comment.createAt).format('YYYY년 MM월 DD일 hh:mm A')}
+              {dayjs(UTCtoLocalTime(comment.createAt)).format(
+                'YYYY년 MM월 DD일 hh:mm A',
+              )}
             </Typography>
           </Box>
         )}

--- a/src/components/board/DetailPanel.tsx
+++ b/src/components/board/DetailPanel.tsx
@@ -5,6 +5,7 @@ import CuButton from '../CuButton'
 import CuModal from '../CuModal'
 import DynamicToastViewer from '../DynamicToastViewer'
 import * as style from './DetailPanel.style'
+import UTCtoLocalTime from '@/utils/UTCtoLocalTime'
 
 type TBoardType = 'NOTICE' | 'BOARD'
 
@@ -155,7 +156,9 @@ export const DetailContent = ({
       </Stack>
       <Stack spacing={'0.5rem'}>
         <ContentTitle title={'작성일'} />
-        <Content content={dayjs(createdAt).format('YYYY-MM-DD')} />
+        <Content
+          content={dayjs(UTCtoLocalTime(createdAt)).format('YYYY-MM-DD')}
+        />
       </Stack>
       <Stack spacing={'0.5rem'}>
         <ContentTitle title={'작성자'} />

--- a/src/types/TeamBoardTypes.ts
+++ b/src/types/TeamBoardTypes.ts
@@ -42,24 +42,15 @@ export interface ITeamNoticeDetail extends ITeamNoticeBase {
   content: string
   isAuthor: boolean
 }
-
-export interface ITeamBoardComment {
+export interface ITeamComment {
   commentId: number
   authorImage: string
   authorNickname: string
   content: string
-  createdAt: Date
+  createAt: Date
+  authorId: number
   isAuthor: boolean
 }
-export interface ITeamComment {
-  answerId: number
-  authorImage: string
-  authorNickname: string
-  content: string
-  createdAt: Date
-  isAuthor: boolean
-}
-
 export interface IEditFormType {
   teamId: string
   postId?: number

--- a/src/utils/UTCtoLocalTime.ts
+++ b/src/utils/UTCtoLocalTime.ts
@@ -1,4 +1,4 @@
-const UTCtoLocalTime = (utcTime: string) => {
+const UTCtoLocalTime = (utcTime: string | Date) => {
   const utcDate = new Date(utcTime)
   return new Date(utcDate.getTime() - utcDate.getTimezoneOffset() * 60 * 1000)
 }


### PR DESCRIPTION
### 관련 이슈

- close #1070 

### 작업 내용

- 댓글 일자 실시간으로 보이는 문제 -> 타입 오류로 undefined로 처리되어 현재 시간을 보여주는 문제였습니다. 타입 통일시켜서 문제 해결했습니다.
   <img width="332" alt="Screen_Shot 2024-02-26 15 52 42" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/0d803242-d734-4ad0-a1f6-278b85194553">
- 게시판에서 처리되는 일자를 local time으로 변환하는 로직 추가