### PR TITLE
[C-MAIN] 메인페이지 무한스크롤에서 페이지네이션으로 변경

### DIFF
--- a/src/app/panel/main-page/MainCarousel.tsx
+++ b/src/app/panel/main-page/MainCarousel.tsx
@@ -1,20 +1,19 @@
 import { Box } from '@mui/material'
-import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 import CuPhotoBox from '@/components/CuPhotoBox'
 
 const MainCarousel = () => {
-  const settings = {
-    dots: true,
-    infinite: true,
-    speed: 500,
-    slidesToShow: 1,
-    slidesToScroll: 1,
-    arrows: false,
-    autoplay: true,
-    autoplaySpeed: 5000,
-  }
+  // const settings = {
+  //   dots: true,
+  //   infinite: true,
+  //   speed: 500,
+  //   slidesToShow: 1,
+  //   slidesToScroll: 1,
+  //   arrows: false,
+  //   autoplay: true,
+  //   autoplaySpeed: 5000,
+  // }
 
   const BoxStyle = {
     width: '100%',
@@ -22,16 +21,16 @@ const MainCarousel = () => {
   }
 
   return (
-    <Slider {...settings}>
-      <Box sx={BoxStyle}>
-        <CuPhotoBox
-          src={'/images/banners/default-mobile.svg'}
-          alt="banner-1"
-          imgStyle={{ borderRadius: '0.75rem' }}
-          style={{ width: 300, height: 130 }}
-        />
-      </Box>
-    </Slider>
+    // <Slider {...settings}>
+    <Box sx={BoxStyle}>
+      <CuPhotoBox
+        src={'/images/banners/default-mobile.svg'}
+        alt="banner-1"
+        imgStyle={{ borderRadius: '0.75rem' }}
+        style={{ width: 300, height: 130 }}
+      />
+    </Box>
+    // </Slider>
   )
 }
 


### PR DESCRIPTION
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/2a824be7-5e39-400d-a51f-3aff1b0a3eb6)
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/603365b4-f8c5-4359-8499-328446b52899)

* 메인페이지 무한스크롤에서 페이지네이션으로 변경
* SSR시 client-side에서 fetch해오지 않도록 하던 부분의 방식 수정 (isInit으로 판단하는게 아닌 fallbackdata를 추가)
* mainCarousel에서 carousel 제거 (지금은 이미지 하나이기 때문에 굳이 필요없음. 오히려 불필요한 리렌더링 유발)
https://github.com/peer-42seoul/Peer-Frontend/issues/1081