### PR TITLE
[1.0.6] PWA 배너 유저 피드백 반영

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   register: true,
   skipWaiting: true,
   disable: prod ? false : true, // 나중에 true로 바꿔야함
+  // disable: true,
   // runtimeCaching,
 })
 

--- a/src/app/panel/PwaInstallBanner.tsx
+++ b/src/app/panel/PwaInstallBanner.tsx
@@ -93,11 +93,13 @@ const PwaInstallBanner = () => {
             }}
           >
             <Stack
+              padding={1}
               margin={1}
               direction={'row'}
               justifyContent={'space-between'}
+              alignItems={'center'}
             >
-              <Typography color={'white'} variant="Caption">
+              <Typography color={'white'} variant="Body1">
                 사용하시는 브라우저는 PWA 기능을 사용하기 위해서는{' '}
                 <IosShareIcon fontSize="small" />
                 [공유하기 버튼]을 눌러서 [홈 화면에 추가]를 해주셔야 합니다.
@@ -126,23 +128,32 @@ const PwaInstallBanner = () => {
           width={'100%'}
           sx={{
             backgroundColor: 'primary.main',
-            zIndex: 9999,
+            zIndex: 400,
             paddingBottom: 0.2,
           }}
         >
-          <Stack margin={1}>
-            <Typography color={'white'} variant="Caption">
+          <Stack margin={1} padding={1} spacing={'1rem'}>
+            <Typography color={'white'} variant="Body1">
               사용하시는 브라우저는 PWA 기능을 사용할 수 있습니다.{' '}
               {isPc ? '데스크탑' : '모바일'}에 설치하시겠습니까?
             </Typography>
-            <Stack direction="row">
-              <Button onClick={handleInstall}>
-                <Typography color={'white'} variant="Caption">
+            <Stack
+              direction="row"
+              alignItems={'center'}
+              display={'flex'}
+              flexDirection={isPc ? 'row' : 'row-reverse'}
+            >
+              <Button
+                variant={'contained'}
+                color="secondary"
+                onClick={handleInstall}
+              >
+                <Typography color={'white'} variant="Body1">
                   설치
                 </Typography>
               </Button>
               <Button onClick={() => setIsShowInstall(false)}>
-                <Typography color={'white'} variant="Caption">
+                <Typography color={'white'} variant="Body1">
                   다음에
                 </Typography>
               </Button>
@@ -152,7 +163,7 @@ const PwaInstallBanner = () => {
                   localStorage.setItem('isShowInstall', 'false')
                 }}
               >
-                <Typography color={'white'} variant="Caption">
+                <Typography color={'white'} variant="Body1">
                   닫기
                 </Typography>
               </Button>


### PR DESCRIPTION
이슈에서 올려진 피드백에 맞춰서 디자인을 약간 수정했습니다. 확인 부탁드립니다.

## 바뀐 점

- 기존 폰트가 Caption으로 되어 있는 부분을 전부 Body1로 맞춤
- 패딩이 없어서 약간 답답한 디자인을 수정
- 행동 유도를 위해 모바일에선 오른쪽에 설치 버튼이 오게끔, 특히 행동을 유도하기 위해 버튼의 색상을 입혔는데 확인 부탁드립니다.

<img width="1440" alt="스크린샷 2024-02-29 오후 6 36 53" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/db8f404b-d346-454f-ba54-e82ce0a22cab">

<img width="817" alt="스크린샷 2024-02-29 오후 6 36 45" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/79005fc6-409d-4216-ab6f-15fd6c8fd4f0">

<img width="398" alt="스크린샷 2024-02-29 오후 6 36 38" src="https://github.com/peer-42seoul/Peer-Frontend/assets/54823522/a30549dc-a983-4594-8517-7904add6c5c4">
