### PR TITLE
[1.0.6] ABOUT 페이지의 Contact us의 max length가 적다는 피드백

### DIFF
--- a/src/app/about/@contact/page.tsx
+++ b/src/app/about/@contact/page.tsx
@@ -179,7 +179,10 @@ const ContactPage = () => {
                 }}
                 {...register('text', {
                   required: '필수 입력 내용입니다.',
-                  maxLength: 300,
+                  maxLength: {
+                    value: 1000,
+                    message: '1000자 이내로 입력해주세요.',
+                  },
                   minLength: {
                     value: 1,
                     message: '1글자 이상 입력해주세요.',


### PR DESCRIPTION
## 바뀐점

- 기존 300자 였던 최대 길이를 이미지를 고려해서 1000자로 늘렸습니다.
- API 저장소에 Validation이 기재가 안된 점을 체크하고 추가했습니다.