### PR TITLE
[1.0.7 / D-TP] 게시물 로딩 메시지 오류 수정

### DIFF
--- a/src/app/teams/[id]/board/@detail/page.tsx
+++ b/src/app/teams/[id]/board/@detail/page.tsx
@@ -53,20 +53,22 @@ const TeamBoardPostView = ({ params }: { params: { id: string } }) => {
   if (!boardId) return null
 
   if (postId === undefined) return null
-  if (!data || error)
-    return (
-      <StatusMessage
-        boardType={'BOARD'}
-        message={'문제가 발생했습니다.'}
-        onClickEditButton={() => setBoard('LIST', boardId, postId)}
-        author={!!data?.isAuthor}
-      />
-    )
+
   if (isLoading)
     return (
       <StatusMessage
         boardType={'BOARD'}
         message={'게시글을 불러오는 중입니다...'}
+        onClickEditButton={() => setBoard('LIST', boardId, postId)}
+        author={!!data?.isAuthor}
+      />
+    )
+
+  if (!data || error)
+    return (
+      <StatusMessage
+        boardType={'BOARD'}
+        message={'문제가 발생했습니다.'}
         onClickEditButton={() => setBoard('LIST', boardId, postId)}
         author={!!data?.isAuthor}
       />

--- a/src/app/teams/[id]/board/@list/panel/BoardPostList.tsx
+++ b/src/app/teams/[id]/board/@list/panel/BoardPostList.tsx
@@ -30,9 +30,11 @@ const BoardPostList = ({
     if (!isLoading && size !== 1) setSize(1)
   }, [keyword])
 
-  if (!data || error) return <StatusMessage message="문제가 발생했습니다." />
   if (!data && isLoading)
     return <StatusMessage message="게시글을 불러오는 중입니다..." />
+
+  if (!data || error) return <StatusMessage message="문제가 발생했습니다." />
+
   if (data.length === 0 || data[0].content.length === 0)
     return <StatusMessage message="등록된 글이 없습니다." />
   return (

--- a/src/app/teams/[id]/notice/@detail/page.tsx
+++ b/src/app/teams/[id]/notice/@detail/page.tsx
@@ -50,15 +50,7 @@ const TeamNoticeView = ({ params }: { params: { id: string } }) => {
   }
 
   if (postId === undefined) return null
-  if (!data || error)
-    return (
-      <StatusMessage
-        boardType={'NOTICE'}
-        message={'문제가 발생했습니다.'}
-        onClickEditButton={() => setNotice('EDIT', postId)}
-        author={!!data?.isAuthor}
-      />
-    )
+
   if (isLoading)
     return (
       <StatusMessage
@@ -68,6 +60,17 @@ const TeamNoticeView = ({ params }: { params: { id: string } }) => {
         author={!!data?.isAuthor}
       />
     )
+
+  if (!data || error)
+    return (
+      <StatusMessage
+        boardType={'NOTICE'}
+        message={'문제가 발생했습니다.'}
+        onClickEditButton={() => setNotice('EDIT', postId)}
+        author={!!data?.isAuthor}
+      />
+    )
+
   return (
     <>
       <DetailPage boardType={'NOTICE'} handleGoBack={handleGoBack}>


### PR DESCRIPTION
### 관련 이슈

- close #1094

### 작업 내용

<img width="500" src="https://github.com/peer-42seoul/Peer-Frontend/assets/57761286/66c3f10f-3db5-4238-8eed-9dc8a0f092ea" />

조건문 순서가 잘못되어 있어서 로딩 컴포넌트 전에 에러 컴포넌트가 먼저 보여지던 문제였습니다.
로딩 조건을 먼저 확인하도록 수정했습니다.