### PR TITLE
[C-MAIN][J-TB] 모집글 카드, 모집글 디테일 페이지에 정보 추가

### DIFF
--- a/src/app/panel/main-page/MainCard.tsx
+++ b/src/app/panel/main-page/MainCard.tsx
@@ -37,6 +37,8 @@ const MainCard = ({
   titleMaxLine = 2,
   tagMaxLine = 2,
 }: IMainCard) => {
+  //글 생성일, 인원
+
   const statusLabel =
     status === 'ONGOING'
       ? '모집중'

--- a/src/app/panel/main-page/MainCard.tsx
+++ b/src/app/panel/main-page/MainCard.tsx
@@ -15,6 +15,7 @@ import FavoriteButton from '@/components/FavoriteButton'
 import { ChipStyle } from '@/app/panel/main-page/MainCard.style'
 import CuPhotoBox from '@/components/CuPhotoBox'
 import dynamic from 'next/dynamic'
+import dayjs from 'dayjs'
 
 const DynamicOtherProfile = dynamic(() => import('@/app/panel/OthersProfile'), {
   loading: () => <></>,
@@ -36,6 +37,8 @@ const MainCard = ({
   sx,
   titleMaxLine = 2,
   tagMaxLine = 2,
+  createdAt,
+  member,
 }: IMainCard) => {
   //글 생성일, 인원
 
@@ -84,7 +87,7 @@ const MainCard = ({
           <CuPhotoBox
             style={{
               width: '100%',
-              height: '194px',
+              height: '160px',
               position: 'relative',
               left: '-2px',
               top: '-2px',
@@ -132,7 +135,7 @@ const MainCard = ({
           <FavoriteButton
             recruit_id={recruit_id}
             favorite={favorite}
-            redirect_url={`/recruit/${recruit_id}?type=${type ?? 'STUDY'}`}
+            redirect_url={`/recruit/${recruit_id}`}
             onFavorite={onFavorite}
           />
         }
@@ -153,7 +156,7 @@ const MainCard = ({
         }
       />
       <Link
-        href={href ?? `/recruit/${recruit_id}?type=${type ?? 'STUDY'}`}
+        href={href ?? `/recruit/${recruit_id}`}
         style={{ textDecoration: 'none' }}
       >
         <CardContent
@@ -178,6 +181,16 @@ const MainCard = ({
           >
             {title}
           </Typography>
+
+          <Stack justifyContent={'space-between'} direction={'row'} mt={0.5}>
+            <Typography variant="Body2" color="text.alternative">
+              {dayjs(createdAt).format('YYYY-MM-DD')}
+            </Typography>
+            <Typography variant="Body2" color="text.alternative">
+              {member}명
+            </Typography>
+          </Stack>
+
           <Stack
             gap={'0.25rem'}
             mt={1}

--- a/src/app/recruit/[id]/panel/RecruitContentText.tsx
+++ b/src/app/recruit/[id]/panel/RecruitContentText.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from '@mui/material'
+import { Grid, Stack, Typography } from '@mui/material'
 
 const RecruitContentText = ({
   label,
@@ -11,26 +11,28 @@ const RecruitContentText = ({
   children?: React.ReactNode
   icon?: React.ReactNode
 }) => (
-  <Stack gap={'0.5rem'}>
-    <Stack direction={'row'} gap={'0.5rem'} alignItems={'center'}>
-      <Stack
-        sx={{ color: 'text.normal', width: '1rem', height: '1rem' }}
-        alignItems={'center'}
-        justifyContent={'center'}
-      >
-        {icon}
+  <Grid xs={6}>
+    <Stack gap={'0.5rem'}>
+      <Stack direction={'row'} gap={'0.5rem'} alignItems={'center'}>
+        <Stack
+          sx={{ color: 'text.normal', width: '1rem', height: '1rem' }}
+          alignItems={'center'}
+          justifyContent={'center'}
+        >
+          {icon}
+        </Stack>
+        <Typography color={'text.strong'} variant="CaptionEmphasis">
+          {label}
+        </Typography>
       </Stack>
-      <Typography color={'text.strong'} variant="CaptionEmphasis">
-        {label}
-      </Typography>
+      {content && (
+        <Typography variant={'Body2'} color={'text.alternative'}>
+          {content}
+        </Typography>
+      )}
+      {children && children}
     </Stack>
-    {content && (
-      <Typography variant={'Body2'} color={'text.alternative'}>
-        {content}
-      </Typography>
-    )}
-    {children && children}
-  </Stack>
+  </Grid>
 )
 
 export default RecruitContentText

--- a/src/app/recruit/[id]/panel/RecruitDetailContent.tsx
+++ b/src/app/recruit/[id]/panel/RecruitDetailContent.tsx
@@ -105,7 +105,7 @@ const RecruitDetailContent = ({
         <RecruitContentText
           label="작성일"
           icon={<DateRangeIcon fontSize={'small'} />}
-          content={dayjs(data?.updatedAt).format('YYYY-MM-DD HH:mm')}
+          content={dayjs(data?.createdAt).format('YYYY-MM-DD HH:mm')}
         />
       </Grid>
       <Stack marginY={'1.5rem'}>

--- a/src/app/recruit/[id]/panel/RecruitDetailContent.tsx
+++ b/src/app/recruit/[id]/panel/RecruitDetailContent.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from '@mui/material'
+import { Grid, Stack, Typography } from '@mui/material'
 import RecruitContentText from '@/app/recruit/[id]/panel/RecruitContentText'
 import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined'
 import { IPostDetail, IRole, ITag, ProjectType } from '@/types/IPostDetail'
@@ -7,6 +7,8 @@ import React from 'react'
 import DynamicToastViewer from '@/components/DynamicToastViewer'
 import * as style from '@/app/recruit/write/page.style'
 import * as Icon from '@/icons'
+import DateRangeIcon from '@mui/icons-material/DateRange'
+import dayjs from 'dayjs'
 
 const RecruitDetailContent = ({
   data,
@@ -18,96 +20,107 @@ const RecruitDetailContent = ({
   roleList: IRole[]
 }) => {
   return (
-    <Stack gap={'1.5rem'}>
-      <RecruitContentText
-        label="팀명"
-        content={data?.teamName}
-        icon={<PersonOutlineOutlinedIcon />}
-      />
-      <RecruitContentText
-        label={type === 'PROJECT' ? '역할' : '인원'}
-        icon={
-          <Icon.TwoPeopleIcon
-            sx={{ ...style.iconStyleBase, color: 'text.normal' }}
-          />
-        }
-      >
-        <Stack flexDirection={'row'} gap={1} alignItems={'center'}>
-          {type === 'STUDY' ? (
-            <Typography
-              variant={'Body2'}
-              color={'text.alternative'}
-            >{`${data?.current}/${data?.totalNumber} 명`}</Typography>
-          ) : (
-            roleList?.map(({ name, number, current }, idx: number) => (
+    <>
+      <Grid container rowGap={'1.5rem'}>
+        <RecruitContentText
+          label="팀명"
+          content={data?.teamName}
+          icon={<PersonOutlineOutlinedIcon />}
+        />
+        <RecruitContentText
+          label={type === 'PROJECT' ? '역할' : '인원'}
+          icon={
+            <Icon.TwoPeopleIcon
+              sx={{ ...style.iconStyleBase, color: 'text.normal' }}
+            />
+          }
+        >
+          <Stack flexDirection={'row'} gap={1} alignItems={'center'}>
+            {type === 'STUDY' ? (
               <Typography
                 variant={'Body2'}
                 color={'text.alternative'}
-                key={idx}
-              >{`${name} ${current}/${number} 명`}</Typography>
-            ))
+              >{`${data?.current}/${data?.totalNumber} 명`}</Typography>
+            ) : (
+              roleList?.map(({ name, number, current }, idx: number) => (
+                <Typography
+                  variant={'Body2'}
+                  color={'text.alternative'}
+                  key={idx}
+                >{`${name} ${current}/${number} 명`}</Typography>
+              ))
+            )}
+          </Stack>
+        </RecruitContentText>
+        <RecruitContentText
+          label="활동방식"
+          content={data?.place}
+          icon={
+            <Icon.WifiIcon
+              sx={{ ...style.iconStyleBase, color: 'text.normal' }}
+            />
+          }
+        />
+        <RecruitContentText
+          icon={
+            <Icon.PieChartIcon
+              sx={{ ...style.iconStyleBase, color: 'text.normal' }}
+            />
+          }
+          label="목표기간"
+          content={data?.due}
+        />
+        <RecruitContentText
+          label="지역"
+          icon={
+            <Icon.LocationIcon
+              sx={{ ...style.iconStyleBase, color: 'text.normal' }}
+            />
+          }
+        >
+          {data?.region ? (
+            <Typography variant={'Body2'} color={'text.alternative'}>
+              {data.region[0] + ' ' + data.region?.[1]}
+            </Typography>
+          ) : (
+            <Typography variant={'Body2'} color={'text.alternative'}>
+              없음
+            </Typography>
           )}
-        </Stack>
-      </RecruitContentText>
-      <RecruitContentText
-        label="활동방식"
-        content={data?.place}
-        icon={
-          <Icon.WifiIcon
-            sx={{ ...style.iconStyleBase, color: 'text.normal' }}
-          />
-        }
-      />
-      <RecruitContentText
-        icon={
-          <Icon.PieChartIcon
-            sx={{ ...style.iconStyleBase, color: 'text.normal' }}
-          />
-        }
-        label="목표기간"
-        content={data?.due}
-      />
-      <RecruitContentText
-        label="지역"
-        icon={
-          <Icon.LocationIcon
-            sx={{ ...style.iconStyleBase, color: 'text.normal' }}
-          />
-        }
-      >
-        {data?.region ? (
-          <Typography variant={'Body2'} color={'text.alternative'}>
-            {data.region[0] + ' ' + data.region?.[1]}
-          </Typography>
-        ) : (
-          <Typography variant={'Body2'} color={'text.alternative'}>
-            없음
-          </Typography>
-        )}
-      </RecruitContentText>
-      <RecruitContentText
-        label="관련 태그"
-        icon={
-          <Icon.TagIcon sx={{ ...style.iconStyleBase, color: 'text.normal' }} />
-        }
-      >
-        <Stack direction={'row'} gap={1} flexWrap={'wrap'}>
-          {data?.tagList?.map((tag: ITag, idx: number) => (
-            <TagChip name={tag?.name} key={idx} color={tag?.color} />
-          ))}
-        </Stack>
-      </RecruitContentText>
-      <RecruitContentText
-        label="설명"
-        icon={
-          <Icon.FileIcon
-            sx={{ ...style.iconStyleBase, color: 'text.normal' }}
-          />
-        }
-      >
-        <DynamicToastViewer initialValue={data?.content} />
-      </RecruitContentText>
-    </Stack>
+        </RecruitContentText>
+        <RecruitContentText
+          label="관련 태그"
+          icon={
+            <Icon.TagIcon
+              sx={{ ...style.iconStyleBase, color: 'text.normal' }}
+            />
+          }
+        >
+          <Stack direction={'row'} gap={1} flexWrap={'wrap'}>
+            {data?.tagList?.map((tag: ITag, idx: number) => (
+              <TagChip name={tag?.name} key={idx} color={tag?.color} />
+            ))}
+          </Stack>
+        </RecruitContentText>
+        <RecruitContentText
+          label="작성일"
+          icon={<DateRangeIcon fontSize={'small'} />}
+          content={dayjs(data?.updatedAt).format('YYYY-MM-DD HH:mm')}
+        />
+      </Grid>
+      <Stack marginY={'1.5rem'}>
+        <RecruitContentText
+          label="설명"
+          icon={
+            <Icon.FileIcon
+              sx={{ ...style.iconStyleBase, color: 'text.normal' }}
+            />
+          }
+        >
+          <DynamicToastViewer initialValue={data?.content} />
+        </RecruitContentText>
+      </Stack>
+    </>
   )
 }
 

--- a/src/app/recruit/[id]/panel/RecruitDetailPage.tsx
+++ b/src/app/recruit/[id]/panel/RecruitDetailPage.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { Typography, Stack, Container, Divider, Box } from '@mui/material'
-import { IPostDetail, ProjectType } from '@/types/IPostDetail'
+import { IPostDetail } from '@/types/IPostDetail'
 import React, { useEffect, useMemo, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import useMedia from '@/hook/useMedia'
 import RecruitQuickMenu from '@/app/recruit/[id]/panel/RecruitQuickMenu'
 import RecruitInfo from './RecruitInfo'
@@ -27,7 +27,7 @@ const RecruitDetailPage = ({
   const [isClient, setIsClient] = useState(false)
   const [content, setCotent] = useState<IPostDetail | undefined>(data)
   const router = useRouter()
-  const type = (useSearchParams().get('type') as ProjectType) ?? 'PROJECT'
+  const type = data?.type ?? 'PROJECT'
   const { isPc } = useMedia()
   const { setHeaderTitle } = useHeaderStore()
   const { nickname } = UseNicknameStore()

--- a/src/app/recruit/[id]/panel/RecruitInfoElement.tsx
+++ b/src/app/recruit/[id]/panel/RecruitInfoElement.tsx
@@ -11,12 +11,7 @@ export const RecruitTitle = ({
   status: TPostStatus | undefined
 }) => {
   return (
-    <Stack
-      flexDirection={'row'}
-      alignItems={'center'}
-      gap={'1rem'}
-      padding={'0.25rem'}
-    >
+    <Stack flexDirection={'row'} alignItems={'center'} gap={'1rem'}>
       <Typography variant={'Title3'}>{title}</Typography>
       <Typography color={'yellow.strong'} variant={'Caption'}>
         {status === 'ONGOING'

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -3,11 +3,10 @@
 import { useRouter } from 'next/navigation'
 import { Stack } from '@mui/material'
 import TeamInfoContainer from './panel/TeamInfoContainer'
-// import TeamDnD from './panel/TeamDnD'
 import CuButton from '@/components/CuButton'
 import { useEffect, useState } from 'react'
 import CuCircularProgress from '@/components/CuCircularProgress'
-import TeamDnD from '@/app/teams/[id]/panel/TeamDnD'
+import NoDataDolphin from '@/components/NoDataDolphin'
 
 const TeamsPage = ({ params }: { params: { id: string } }) => {
   const [isClient, setIsClient] = useState(false)
@@ -33,7 +32,19 @@ const TeamsPage = ({ params }: { params: { id: string } }) => {
         style={{ width: 'fit-content' }}
       />
       <TeamInfoContainer id={Number(id)} />
-      <TeamDnD id={id} />
+      <Stack
+        width={'100%'}
+        height={'100%'}
+        alignItems={'center'}
+        justifyContent={'center'}
+        sx={{
+          borderRadius: '1rem',
+          backgroundColor: 'background.secondary',
+        }}
+      >
+        <NoDataDolphin message="메인 팀페이지는 준비중입니다!" />
+      </Stack>
+      {/*<TeamDnD id={id} />*/}
     </Stack>
   )
 }

--- a/src/types/IPostDetail.ts
+++ b/src/types/IPostDetail.ts
@@ -27,6 +27,8 @@ export interface IMainCard {
   sx?: SxProps
   titleMaxLine?: number
   tagMaxLine?: number
+  createdAt?: string
+  member?: number
 }
 
 export interface IPost {
@@ -42,6 +44,7 @@ export interface IPost {
 }
 
 export interface IPostDetail {
+  type: ProjectType
   title: string
   status: TPostStatus
   due: string
@@ -61,6 +64,7 @@ export interface IPostDetail {
   favorite: boolean
   teamName: string
   updatedAt: string
+  createdAt: string
 }
 
 export interface IFormInterview {

--- a/src/types/IPostDetail.ts
+++ b/src/types/IPostDetail.ts
@@ -60,6 +60,7 @@ export interface IPostDetail {
   current?: number
   favorite: boolean
   teamName: string
+  updatedAt: string
 }
 
 export interface IFormInterview {


### PR DESCRIPTION
![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/02e83d5c-d353-41fe-b1f3-94d4df87df0d)
* 메인페이지 모집글 카드에 생성일, 인원 추가
* 모집글 카드의 이미지의 사이즈를 좀 줄였습니다.

![image](https://github.com/peer-42seoul/Peer-Frontend/assets/94117828/b2af4fc3-8a5c-4809-b7a0-7b6eff8325dc)
* 모집글 디테일의 정보들을 2줄로 나열
* 작성일 추가
* 전체 탭 추가에 따른 스터디/프로젝트 구분 법을 url의 쿼리스트링이 아닌 모집글의 타입을 확인하여 구분하도록 수정했습니다.

* dnd 기능을 막아놓았습니다.
